### PR TITLE
adding content location header description

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,5 +11,6 @@
 * [Hypermedia](hyper-media/Hypermedia.md)
 * [Data Formats](data-formats/DataFormats.md)
 * [Common Data Objects](common-data-objects/CommonDataObjects.md)
-* [Common Headers](common-headers/CommonHeaders.md)
+* [Common Headers](headers/CommonHeaders.md)
+* [Proprietary Headers](headers/ProprietaryHeaders.md)
 * [API Discovery](api-discovery/ApiDiscovery.md)

--- a/headers/CommonHeaders.md
+++ b/headers/CommonHeaders.md
@@ -1,0 +1,19 @@
+# Common Headers
+
+This section describes a handful of headers, which we found raised the most questions in our daily usage.
+
+## Content-Location
+
+This header is used in the response of either a GET, HEAD, PUT, POST or PATCH request. In the case of the GET requests it
+points to a location where an alternate representation of the entity in the response body can be found. In this case one
+has to set the Content-Type header as well. For example:
+
+    GET /product-images/123
+    Content-Type: image/png
+    Content-Location: /product-images/123?format=png
+
+In the case of mutating HTTP methods the Content-Location header is used, when there is a response body. If the Content-Location
+is the same than the Location header it means, that the returned body is indeed the current representation of the entity, making
+a subsequent GET operation from the client side not necessary.
+
+More details in [rfc7231](https://tools.ietf.org/html/rfc7231#section-3.1.4.2)

--- a/headers/CommonHeaders.md
+++ b/headers/CommonHeaders.md
@@ -4,16 +4,29 @@ This section describes a handful of headers, which we found raised the most ques
 
 ## Content-Location
 
-This header is used in the response of either a GET, HEAD, PUT, POST or PATCH request. In the case of the GET requests it
-points to a location where an alternate representation of the entity in the response body can be found. In this case one
+This header is used in the response of either a successful read (GET, HEAD) or successful write operation (PUT, POST or PATCH).
+
+In the case of the GET requests it points to a location where an alternate representation of the
+entity in the response body can be found. In this case one
 has to set the Content-Type header as well. For example:
 
-    GET /product-images/123
-    Content-Type: image/png
-    Content-Location: /product-images/123?format=png
+```http
+GET /products/123/images HTTP/1.1
 
-In the case of mutating HTTP methods the Content-Location header is used, when there is a response body. If the Content-Location
-is the same than the Location header it means, that the returned body is indeed the current representation of the entity, making
-a subsequent GET operation from the client side not necessary.
+HTTP/1.1 200 OK
+Content-Type: image/png
+Content-Location: /products/123/images?format=raw
+```
+
+In the case of mutating HTTP methods, the Content-Location header can be used when there is a response body,
+and then it indicates that the included response body can be found at the location indicated in the header.
+
+If the header value is the same as the location of the created resource (as indicated by the Location header
+after POST) or the modified resource (as indicated by the request URI after PUT / PATCH), then the returned
+body is indeed the current representation of the entity making a subsequent GET operation from the client side
+not necessary.
+
+If your API returns the new representation after a PUT, PATCH, or POST you should include the Content-Location header
+to make it explicit, that the returned resource is an up-to-date version.
 
 More details in [rfc7231](https://tools.ietf.org/html/rfc7231#section-3.1.4.2)

--- a/headers/ProprietaryHeaders.md
+++ b/headers/ProprietaryHeaders.md
@@ -1,4 +1,4 @@
-# Common Headers
+# Proprietary Headers
 
 This section shares definitions of proprietary headers that should be named consistently because
 they address overarching service-related concerns. Whether services support these concerns or not is

--- a/http/Http.md
+++ b/http/Http.md
@@ -90,7 +90,7 @@ different HTTP methods on resources.
 | Code | Meaning | Methods |
 | --   | --      | --                 |
 | 200  | OK - this is the standard success response | All |
-| 201  | Created - Returned on successful entity creation. You are free to return either an empty response or the created resource in conjunction with the Content-Location header. (More details found [here](../headers/CommonHeaders.html).) *Always* set the Location header. | POST, PUT |
+| 201  | Created - Returned on successful entity creation. You are free to return either an empty response or the created resource in conjunction with the Content-Location header. (More details found in the [Common Headers section](../headers/CommonHeaders.html).) *Always* set the Location header. | POST, PUT |
 | 202  | Accepted - The request was successful and will be processed asynchronously. | POST, PUT, DELETE, PATCH |
 | 204  | No content - There is no response body | PUT, DELETE |
 

--- a/http/Http.md
+++ b/http/Http.md
@@ -90,7 +90,7 @@ different HTTP methods on resources.
 | Code | Meaning | Methods |
 | --   | --      | --                 |
 | 200  | OK - this is the standard success response | All |
-| 201  | Created - Returned on successful entity creation. You are free to return either an empty response or the created resource in conjunction with the Content-Location header.  Always set the Location header. | POST, PUT |
+| 201  | Created - Returned on successful entity creation. You are free to return either an empty response or the created resource in conjunction with the Content-Location header. (More details found [here](../headers/CommonHeaders.html).) *Always* set the Location header. | POST, PUT |
 | 202  | Accepted - The request was successful and will be processed asynchronously. | POST, PUT, DELETE, PATCH |
 | 204  | No content - There is no response body | PUT, DELETE |
 


### PR DESCRIPTION
I would like to add this section to provide a background, why we require to add a content location header in the response of mutating requests. There were quite a few comments and questions regarding this during our reviews.