### PR TITLE
Introducing resources chapter for resource-specific rules

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,6 +6,7 @@
 * [Security](security/Security.md)
 * [Compatibility](compatibility/Compatibility.md)
 * [Naming](naming/Naming.md)
+* [Resources](resources/Resources.md)
 * [HTTP](http/Http.md)
 * [Pagination](pagination/Pagination.md)
 * [Hypermedia](hyper-media/Hypermedia.md)

--- a/general-guidelines/GeneralGuidelines.md
+++ b/general-guidelines/GeneralGuidelines.md
@@ -16,29 +16,3 @@ using the “externalDocs” property in your RESTful API OpenAPI definition and
 GitHub Enterprise pages, on specific team web servers, or as a Google doc.
 
 ## {{ book.must }} Write APIs in U.S. English
-
-## {{ book.must }} Avoid Actions — Think About Resources
-
-REST is all about your resources, so consider the domain entities that take part in web service interaction, and aim to model your API around these using the standard HTTP methods as operation indicators. For instance, if an application has to lock articles explicitly so that only one user may edit them, create an article lock with PUT or POST instead of using a lock action.
-
-Request:
-
-    PUT /article-locks/{article-id}
-
-The added benefit is that you already have a service for browsing and filtering article locks.
-
-## {{ book.should }} Define *useful* resources
-
-As a rule of thumb resources should be defined to cover 90% of all its client's use cases. A *useful* resource should
-contain as much information as necessary, but as little as possible. A great way to support the last 10% is to allow
-clients to specify their needs for more/less information by supporting filtering and
-[embedding](../hyper-media/Hypermedia.md#should-allow-embedding-of-complex-subresources).
-
-## {{ book.must }} Keep URLs Verb-Free
-
-The API describes resources, so the only place where actions should appear is in the HTTP methods.
-In URLs, use only nouns.
-
-## {{ book.must }} Use Domain-Specific Resource Names
-
-API resources represent elements of the application’s domain model. Using domain-specific nomenclature for resource names helps developers to understand the functionality and basic semantics of your resources. It also reduces the need for further documentation outside the API definition. For example, “sales-order-items” is superior to “order-items” in that it clearly indicates which business object it represents. Along these lines, “items” is too general.

--- a/naming/Naming.md
+++ b/naming/Naming.md
@@ -49,36 +49,6 @@ your OpenAPI definition.
 
 Usually, a collection of resource instances is provided (at least API should be ready here). The special case of a resource singleton is a collection with cardinality 1.
 
-## {{ book.must }} Identify resources and Sub-Resources via Path Segments
-
-Basic URL structure:
-
-    /{resources}/[resource-id]/{sub-resources}/[sub-resource-id]
-
-Examples:
-
-    /carts/1681e6b88ec1/items
-    /carts/1681e6b88ec1/items/1
-
-## {{ book.could }} Consider Using (Non-) Nested URLs
-
-If a sub-resource is only accessible via its parent resource and may not exists without parent resource, consider using a nested URL structure, for instance:
-
-    /carts/1681e6b88ec1/cart-items/1
-
-However, if the resource can be accessed directly via its unique id, then the API should expose it as a top-level resource. For example, customer is a collection for sales orders; however, sales orders have globally unique id and some services may choose to access the orders directly, for instance:
-
-    /customer/1681e6b88ec1
-    /sales-order/5273gh3k525a
-
-## {{ book.should }} Limit of Resources
-
-To keep maintenance manageable, and to avoid violations of the “separation of concern” principle, an API should not expose more than 16 resources. If you exceed 16 resources, first check if you can split them into separate subdomains with distinct APIs.
-
-## {{ book.should }} Limit of Sub-Resource Levels
-
-There are main resources (with root url paths) and sub-resources (or “nested” resources with non-root urls paths). Use sub-resources if their life cycle is (loosely) coupled to the main resource, i.e. the main resource works as collection resource of the subresource entities. You should use <= 3 sub-resource (nesting) levels -- more levels increase API complexity and url path length. (Remember, some popular web browsers do not support URLs of more than 2000 characters)
-
 ## {{ book.could }} First Path segment May be /api
 
 In most cases, all resources provided by a service are part of the public API, and therefore should

--- a/resources/Resources.md
+++ b/resources/Resources.md
@@ -1,0 +1,57 @@
+# Resources
+
+## {{ book.must }} Avoid Actions — Think About Resources
+
+REST is all about your resources, so consider the domain entities that take part in web service interaction, and aim to model your API around these using the standard HTTP methods as operation indicators. For instance, if an application has to lock articles explicitly so that only one user may edit them, create an article lock with PUT or POST instead of using a lock action.
+
+Request:
+
+    PUT /article-locks/{article-id}
+
+The added benefit is that you already have a service for browsing and filtering article locks.
+
+## {{ book.should }} Define *useful* resources
+
+As a rule of thumb resources should be defined to cover 90% of all its client's use cases. A *useful* resource should
+contain as much information as necessary, but as little as possible. A great way to support the last 10% is to allow
+clients to specify their needs for more/less information by supporting filtering and
+[embedding](../hyper-media/Hypermedia.md#should-allow-embedding-of-complex-subresources).
+
+## {{ book.must }} Keep URLs Verb-Free
+
+The API describes resources, so the only place where actions should appear is in the HTTP methods.
+In URLs, use only nouns.
+
+## {{ book.must }} Use Domain-Specific Resource Names
+
+API resources represent elements of the application’s domain model. Using domain-specific nomenclature for resource names helps developers to understand the functionality and basic semantics of your resources. It also reduces the need for further documentation outside the API definition. For example, “sales-order-items” is superior to “order-items” in that it clearly indicates which business object it represents. Along these lines, “items” is too general.
+
+## {{ book.must }} Identify resources and Sub-Resources via Path Segments
+
+Basic URL structure:
+
+    /{resources}/[resource-id]/{sub-resources}/[sub-resource-id]
+
+Examples:
+
+    /carts/1681e6b88ec1/items
+    /carts/1681e6b88ec1/items/1
+
+## {{ book.could }} Consider Using (Non-) Nested URLs
+
+If a sub-resource is only accessible via its parent resource and may not exists without parent resource, consider using a nested URL structure, for instance:
+
+    /carts/1681e6b88ec1/cart-items/1
+
+However, if the resource can be accessed directly via its unique id, then the API should expose it as a top-level resource. For example, customer is a collection for sales orders; however, sales orders have globally unique id and some services may choose to access the orders directly, for instance:
+
+    /customer/1681e6b88ec1
+    /sales-order/5273gh3k525a
+
+## {{ book.should }} Limit of Resources
+
+To keep maintenance manageable, and to avoid violations of the “separation of concern” principle, an API should not expose more than 16 resources. If you exceed 16 resources, first check if you can split them into separate subdomains with distinct APIs.
+
+## {{ book.should }} Limit of Sub-Resource Levels
+
+There are main resources (with root url paths) and sub-resources (or “nested” resources with non-root urls paths). Use sub-resources if their life cycle is (loosely) coupled to the main resource, i.e. the main resource works as collection resource of the subresource entities. You should use <= 3 sub-resource (nesting) levels -- more levels increase API complexity and url path length. (Remember, some popular web browsers do not support URLs of more than 2000 characters)


### PR DESCRIPTION
Some editorial changes, suggested by @tfrauenstein 

All resource-related rules are grouped in own chapter.