### PR TITLE
Remove duplicated ISO guidance.

### DIFF
--- a/data-formats/DataFormats.md
+++ b/data-formats/DataFormats.md
@@ -14,19 +14,6 @@ A zone offset may be used (both, in request and responses) -- this is simply def
 
 When it comes to storage, all dates should be consistently stored in UTC without zone offset. Localization should be done locally by the services that provide user interfaces, if required.
 
-## {{ book.could }} Use Standard Data Formats
-
-* [ISO 3166-1-alpha2 country codes](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
-
-* * (It's “GB”, not “UK”, even though “UK” has seen some use at Zalando)
-
-* [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
-
-* * [BCP-47](https://tools.ietf.org/html/bcp47) (based on ISO 639-1) for language variants
-
-* [ISO 4217 currency codes](http://en.wikipedia.org/wiki/ISO_4217)
-
-
 ## {{ book.could }} Use Standards for Country, Language and Currency Codes
 
 Use the following standard formats for country, language and currency codes:


### PR DESCRIPTION
Looks like the ISO guidance is repeated. This removes `Use Standard Data Formats` and leaves `Use Standards for Country, Language and Currency Codes` in place.