### PR TITLE
Creating a references section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -15,3 +15,4 @@
 * [Common Headers](headers/CommonHeaders.md)
 * [Proprietary Headers](headers/ProprietaryHeaders.md)
 * [API Discovery](api-discovery/ApiDiscovery.md)
+* [References](references/References.md)

--- a/data-formats/DataFormats.md
+++ b/data-formats/DataFormats.md
@@ -2,7 +2,8 @@
 
 ## {{ book.must }} Use JSON as the Body Payload
 
-JSON-encode the body payload. The JSON payload must follow RFC-7158 and be compatible with RFC-4627 clients by having (if possible) a serialized object or array as the top-level object.
+JSON-encode the body payload. The JSON payload must follow [RFC-7159](https://tools.ietf.org/html/rfc7159) by having
+(if possible) a serialized object or array as the top-level object.
 
 ## {{ book.must }} Use Standard Date and Time Formats
 

--- a/design-principles/DesignPrinciples.md
+++ b/design-principles/DesignPrinciples.md
@@ -19,15 +19,15 @@ Robustness Principle](http://en.wikipedia.org/wiki/Robustness_principle) (RFC 11
 Read the following to gain additional insight on the RESTful service architecture paradigm and
 general RESTful API design style:
 
-- Fielding Dissertation: [Architectural Styles and the Design of Network-Based Software
+* Fielding Dissertation: [Architectural Styles and the Design of Network-Based Software
   Architectures](http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm)
-- Book: [REST in Practice: Hypermedia and Systems
+* Book: [REST in Practice: Hypermedia and Systems
   Architecture](http://www.amazon.de/REST-Practice-Hypermedia-Systems-Architecture/dp/0596805829)
-- Book: [Build APIs You Won't
+* Book: [Build APIs You Won't
   Hate](https://leanpub.com/build-apis-you-wont-hate)
-- InfoQ eBook: [Web APIs: From Start to
+* InfoQ eBook: [Web APIs: From Start to
   Finish](http://www.infoq.com/minibooks/emag-web-api)
-- Lessons-learned blog: [Thoughts on RESTful API
+* Lessons-learned blog: [Thoughts on RESTful API
   Design](http://restful-api-design.readthedocs.org/en/latest/)
 
 We apply the RESTful web service principles to all kind of application components, whether they provide functionality via the internet or via the intranet as larger application elements. We strive to build interoperating distributed systems that different teams can evolve in parallel.

--- a/http/Http.md
+++ b/http/Http.md
@@ -129,7 +129,7 @@ different HTTP methods on resources.
 | 501 | Not Implemented -  server cannot fulfill the request (usually implies future availability, e.g. new feature). | All |
 | 503 | Service Unavailable - server is (temporarily) not available (e.g. due to overload) -- client retry may be senseful. | All |
 
-All error codes you can find at [W3C](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) and [Wikipedia](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) or via https://httpstatuses.com/<error_code>.
+All error codes you can find in [RFC7231](https://tools.ietf.org/html/rfc7231#section-6) and [Wikipedia](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) or via https://httpstatuses.com/<error_code>.
 
 ## {{ book.must }} Providing Error Documentation
 

--- a/references/References.md
+++ b/references/References.md
@@ -1,0 +1,30 @@
+# References
+
+This section collects links to documents to which we refer, and base our guidelines on.
+
+## RFCs
+
+* [RFC 3339: Date and Time on the Internet: Timestamps](https://tools.ietf.org/html/rfc3339)
+* [RFC 5988: Web Linking](https://tools.ietf.org/html/rfc5988)
+* [RFC 7230: Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing](https://tools.ietf.org/html/rfc7230)
+* [RFC 7231: Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content](https://tools.ietf.org/html/rfc7231)
+* [RFC 7807: Problem Details for HTTP APIs](https://tools.ietf.org/html/rfc7807)
+
+## Dissertations
+
+* [Roy Thomas Fielding - Architectural Styles and the Design of Network-Based Software
+  Architectures](http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm)
+
+## Books
+
+* [REST in Practice: Hypermedia and Systems
+  Architecture](http://www.amazon.de/REST-Practice-Hypermedia-Systems-Architecture/dp/0596805829)
+* [Build APIs You Won't
+  Hate](https://leanpub.com/build-apis-you-wont-hate)
+* [InfoQ eBook - Web APIs: From Start to
+  Finish](http://www.infoq.com/minibooks/emag-web-api)
+
+## Blogs
+
+- [Lessons-learned blog: Thoughts on RESTful API
+  Design](http://restful-api-design.readthedocs.org/en/latest/)

--- a/references/References.md
+++ b/references/References.md
@@ -2,13 +2,23 @@
 
 This section collects links to documents to which we refer, and base our guidelines on.
 
+## OpenAPI Specification
+
+* [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/)
+
 ## RFCs
 
 * [RFC 3339: Date and Time on the Internet: Timestamps](https://tools.ietf.org/html/rfc3339)
 * [RFC 5988: Web Linking](https://tools.ietf.org/html/rfc5988)
+* [RFC 7159: The JavaScript Object Notation (JSON) Data Interchange Format](https://tools.ietf.org/html/rfc7159)
 * [RFC 7230: Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing](https://tools.ietf.org/html/rfc7230)
 * [RFC 7231: Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content](https://tools.ietf.org/html/rfc7231)
 * [RFC 7807: Problem Details for HTTP APIs](https://tools.ietf.org/html/rfc7807)
+* [ISO 8601: Date and time format](https://en.wikipedia.org/wiki/ISO_8601)
+* [ISO 3166-1 alpha-2: Two letter country codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+* [ISO 639-1: Two letter language codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+* [ISO 4217: Currency codes](https://en.wikipedia.org/wiki/ISO_4217)
+* [BCP 47: Tags for Identifying Languages](https://tools.ietf.org/html/bcp47)
 
 ## Dissertations
 

--- a/references/References.md
+++ b/references/References.md
@@ -6,7 +6,7 @@ This section collects links to documents to which we refer, and base our guideli
 
 * [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/)
 
-## RFCs
+## Publications, specifications and standards
 
 * [RFC 3339: Date and Time on the Internet: Timestamps](https://tools.ietf.org/html/rfc3339)
 * [RFC 5988: Web Linking](https://tools.ietf.org/html/rfc5988)
@@ -23,7 +23,8 @@ This section collects links to documents to which we refer, and base our guideli
 ## Dissertations
 
 * [Roy Thomas Fielding - Architectural Styles and the Design of Network-Based Software
-  Architectures](http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm)
+  Architectures](http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm).
+  This is the text which defines what REST is.
 
 ## Books
 


### PR DESCRIPTION
To be able to see in one page on, which documents we base our guidelines
I have collected the references from the guidelines. In this move I have
updated one reference to an obsolete RFC and made some markdown
formatting consistent with other sections in the document.