### PR TITLE
Added hint to pagination and ux related issues

### DIFF
--- a/pagination/Pagination.md
+++ b/pagination/Pagination.md
@@ -13,6 +13,10 @@ There are two page iteration techniques:
   unique key element identifies the first page entry (see also
   [Facebook’s guide](https://developers.facebook.com/docs/graph-api/using-graph-api/v2.4#paging))
 
+The technical conception of pagination should also consider user experience related issues. As mentioned
+in this [article](https://www.smashingmagazine.com/2016/03/pagination-infinite-scrolling-load-more-buttons/),
+jumping to a specific page is far less used than navigation via next/previous page links. This favours
+cursor-based over offset-based pagination.
 
 ## {{ book.should }} Prefer Cursor-Based Pagination, Avoid Offset-Based Pagination
 


### PR DESCRIPTION
After an internal discussion about an article which states that ux researches shows load more and next/previous page navigation is favoured by users and results in better conversions than page number navigation, this change adds reference to this in pagination chapter.