### PR TITLE
Some tweaks for the API discovery section.

### DIFF
--- a/api-discovery/ApiDiscovery.md
+++ b/api-discovery/ApiDiscovery.md
@@ -7,12 +7,11 @@ online access to the API definitions of all running applications. All service ap
 provide the following two API endpoints:
 
 * endpoint(s) for GET access on its API OpenAPI definition(s), for instance
-  `https://example.com/swagger.json`. Twintip currently supports only JSON format, though you can
-   in addition also have the API in YAML format.
+  `https://example.com/swagger.json` or `https://example.com/swagger.yaml`.
 * “Twintip” discovery endpoint `https://example.com/.well-known/schema-discovery` that delivers
   the OpenAPI definition endpoint(s) above (see the link below for a description of its format).
 
-Note, these discovery endpoints have to be supported but need not be part of the OpenAPI definition as they do not provide API specific information.
+Note, these discovery endpoints have to be supported but need not be part of the OpenAPI definition as there is no API specific information in their description.
 
 Background: [Twintip](http://docs.stups.io/en/latest/components/twintip.html) is an API definition
 crawler of the STUPS infrastructure; it checks all running applications via the endpoint above and

--- a/api-discovery/ApiDiscovery.md
+++ b/api-discovery/ApiDiscovery.md
@@ -7,15 +7,17 @@ online access to the API definitions of all running applications. All service ap
 provide the following two API endpoints:
 
 * endpoint(s) for GET access on its API OpenAPI definition(s), for instance
-  `https://myapi.com/swagger.json`. Either .json or .yaml formats are supported.
-* “Twintip” discovery endpoint `https://myapi.com/.well-known/schema-discovery` that delivers
-  the OpenAPI definition endpoint(s) above
+  `https://example.com/swagger.json`. Twintip currently supports only JSON format, though you can
+   in addition also have the API in YAML format.
+* “Twintip” discovery endpoint `https://example.com/.well-known/schema-discovery` that delivers
+  the OpenAPI definition endpoint(s) above (see the link below for a description of its format).
 
 Note, these discovery endpoints have to be supported but need not be part of the OpenAPI definition as they do not provide API specific information.
 
 Background: [Twintip](http://docs.stups.io/en/latest/components/twintip.html) is an API definition
 crawler of the STUPS infrastructure; it checks all running applications via the endpoint above and
-stores the discovered API definitions. Twintip itself provides a RESTful API as well as an API Viewer (OpenAPI GUI) for central access to all discovered API definitions.
+stores the discovered API definitions. Twintip itself provides a RESTful API as well as an
+API Viewer (Swagger-UI) for central access to all discovered API definitions.
 
 For the time being, this document is an appropriate place to mention this rule, even though it is
 not a RESTful API definition rule or related to our STUPS infrastructure for application service


### PR DESCRIPTION
Resulting from the review of a68803b in #41, some minor changes:

* use `example.com` instead of `myapi.com` in the example URIs.
  (It was previously changed from myapp.myteam.zalan.do into myapi.com.)
* mention that Twintip only understands JSON
* the tool is still named "Swagger UI", not "OpenAPI GUI".