### PR TITLE
Updated rules for hypermedia and links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@
 node_modules
 
 # gitbook
-*/_book
+/_book
+/_site
 _book
 *.epub
 *.mobi

--- a/data-formats/DataFormats.md
+++ b/data-formats/DataFormats.md
@@ -3,7 +3,9 @@
 ## {{ book.must }} Use JSON as the Body Payload
 
 JSON-encode the body payload. The JSON payload must follow [RFC-7159](https://tools.ietf.org/html/rfc7159) by having
-(if possible) a serialized object or array as the top-level object.
+(if possible) a serialized object as the top-level structure, since it would allow for future extension.
+This also applies for collection resources where one naturally would assume an array. See the
+[pagination](../pagination/Pagination.md#could-use-pagination-links-where-applicable) section for an example.
 
 ## {{ book.must }} Use Standard Date and Time Formats
 

--- a/hyper-media/Hypermedia.md
+++ b/hyper-media/Hypermedia.md
@@ -39,6 +39,12 @@ Interesting articles for comparisons of different hypermedia formats:
 * [Kevin Sookocheff’s On choosing a hypermedia type for your API](http://sookocheff.com/post/api/on-choosing-a-hypermedia-format/)
 * [Mike Stowe's API Best Practices: Hypermedia](http://blogs.mulesoft.com/dev/api-dev/api-best-practices-hypermedia-part-3/)
 
+## {{ book.must }} Do Not Use Link Headers with JSON entities
+
+We don't allow the use of the [`Link` Header defined by RFC 5988 ](http://tools.ietf.org/html/rfc5988#section-5) 
+in conjunction with JSON media types, and favor [HAL](#must-use-hal) instead. The primary reason is to have a consistent
+place for links as well as the better support for links in JSON payloads compared to the uncommon link header syntax.
+
 ## {{ book.could }} Use URIs for Custom Link Relations
 
 You should consider using a custom link relation if and only if standard [link relations](http://www.iana.org/assignments/link-relations/link-relations.xml)

--- a/hyper-media/Hypermedia.md
+++ b/hyper-media/Hypermedia.md
@@ -14,8 +14,7 @@ Links to other resources must be defined exclusively using [HAL](http://stateles
 preferably using standard [link relations](http://www.iana.org/assignments/link-relations/link-relations.xml).
 
 Clients and Servers are required to support `_links` with its `href` and `rel` attributes, not only at the root level
-but also in nested objects. To reduce the effort needed by clients to process hypertext data from servers it's not
-required to implement CURIEs, URI templates or embedded resources. Nor is it required to support the HAL media type
+but also in nested objects. To reduce the effort needed by clients to process hypertext data from servers it's not recommended to serve data with CURIEs, URI templates or embedded resources. Nor is it required to support the HAL media type
 `application/hal+json`.
 
 We opted for this subset of HAL after conducting a comparison of different hypermedia formats based on properties like:

--- a/hyper-media/Hypermedia.md
+++ b/hyper-media/Hypermedia.md
@@ -18,7 +18,7 @@ but also in nested objects. To reduce the effort needed by clients to process hy
 required to implement CURIEs, URI templates or embedded resources. Nor is it required to support the HAL media type
 `application/hal+json`.
 
-We opted for this subset of HAL after conduction a comparison of different hypermedia formats based on properties like:
+We opted for this subset of HAL after conducting a comparison of different hypermedia formats based on properties like:
 
 * Simplicity: resource link syntax and concepts are easy to understand and interpret for API clients.
 * Compatibility: introducing and adding links to resources is not breaking existing API clients.
@@ -41,7 +41,7 @@ Interesting articles for comparisons of different hypermedia formats:
 
 ## {{ book.must }} Do Not Use Link Headers with JSON entities
 
-We don't allow the use of the [`Link` Header defined by RFC 5988 ](http://tools.ietf.org/html/rfc5988#section-5) 
+We don't allow the use of the [`Link` Header defined by RFC 5988](http://tools.ietf.org/html/rfc5988#section-5) 
 in conjunction with JSON media types, and favor [HAL](#must-use-hal) instead. The primary reason is to have a consistent
 place for links as well as the better support for links in JSON payloads compared to the uncommon link header syntax.
 

--- a/hyper-media/Hypermedia.md
+++ b/hyper-media/Hypermedia.md
@@ -28,7 +28,8 @@ We opted for this subset of HAL after conducting a comparison of different hyper
 
 | Standard                                                       | Simplicity | Compatibility | Adoption | Primary Focus           | Docs |
 |----------------------------------------------------------------|------------|---------------|----------|-------------------------|------|
-| [HAL](http://stateless.co/hal_specification.html)              | ✓          | ✓             | ✓        | Links and relationships | ✓    |
+| HAL Subset                                                     | ✓          | ✓             | ✓        | Links and relationships | ✓    |
+| [HAL](http://stateless.co/hal_specification.html)              | ✗          | ✓             | ✓        | Links and relationships | ✓    |
 | [JSON API](http://jsonapi.org/)                                | ✗          | ✗             | ✓        | Response format         | ✓    |
 | [JSON-LD](http://json-ld.org/)                                 | ✗          | ✓             | ?        | Link data               | ?    |
 | [Siren](https://github.com/kevinswiber/siren)                  | ✗          | ✗             | ✗        | Entities and navigation | ✗    |

--- a/hyper-media/Hypermedia.md
+++ b/hyper-media/Hypermedia.md
@@ -4,13 +4,47 @@
 
 We prefer [REST Maturity Level 2](http://martinfowler.com/articles/richardsonMaturityModel.html#level2). Only if HATEOAS - as [Level 3](http://martinfowler.com/articles/richardsonMaturityModel.html#level3) - adds value to your API, consider using it. Because we are following API First, HATEOAS adds not much value for us in terms of self-descriptiveness. And we don't believe in generic HATEOAS clients which crawl and use APIs on their own. So, only use HATEOAS if your API really defines possible client actions (one part of hypermedia) and leverages other HATEOAS features.
 
-Decoupled from HATEOAS, adding links and relationships should be considered as useful addition to APIs as it adds context and helps navigation in APIs to decent degree.
+Decoupled from HATEOAS, adding [links and relationships](#must-use-hal) should be considered as useful addition to APIs as it adds context and helps navigation in APIs to decent degree.
 
 Additional resources: [Wikipedia](http://en.wikipedia.org/wiki/HATEOAS), [The RESTful CookBook](http://restcookbook.com/Basics/hateoas/)
 
+## {{ book.must }} Use a well-defined subset of HAL
+
+Links to other resources must be defined exclusively using [HAL](http://stateless.co/hal_specification.html) and
+preferably using standard [link relations](http://www.iana.org/assignments/link-relations/link-relations.xml).
+
+Clients and Servers are required to support `_links` with its `href` and `rel` attributes, not only at the root level
+but also in nested objects. To reduce the effort needed by clients to process hypertext data from servers it's not
+required to implement CURIEs, URI templates or embedded resources. Nor is it required to support the HAL media type
+`application/hal+json`.
+
+We opted for this subset of HAL after conduction a comparison of different hypermedia formats based on properties like:
+
+* Simplicity: resource link syntax and concepts are easy to understand and interpret for API clients.
+* Compatibility: introducing and adding links to resources is not breaking existing API clients.
+* Adoption: use in open-source libraries and tools as well as other companies
+* Docs: degree of good documentation
+
+<p></p>
+
+| Standard                                                       | Simplicity | Compatibility | Adoption | Primary Focus           | Docs |
+|----------------------------------------------------------------|------------|---------------|----------|-------------------------|------|
+| [HAL](http://stateless.co/hal_specification.html)              | ✓          | ✓             | ✓        | Links and relationships | ✓    |
+| [JSON API](http://jsonapi.org/)                                | ✗          | ✗             | ✓        | Response format         | ✓    |
+| [JSON-LD](http://json-ld.org/)                                 | ✗          | ✓             | ?        | Link data               | ?    |
+| [Siren](https://github.com/kevinswiber/siren)                  | ✗          | ✗             | ✗        | Entities and navigation | ✗    |
+| [Collection+JSON](http://amundsen.com/media-types/collection/) | ✗          | ✗             | ✗        | Collections and queries | ✗    |
+
+Interesting articles for comparisons of different hypermedia formats:
+* [Kevin Sookocheff’s On choosing a hypermedia type for your API](http://sookocheff.com/post/api/on-choosing-a-hypermedia-format/)
+* [Mike Stowe's API Best Practices: Hypermedia](http://blogs.mulesoft.com/dev/api-dev/api-best-practices-hypermedia-part-3/)
+
 ## {{ book.could }} Use URIs for Custom Link Relations
 
-Related or even embedded (sub-) resources should be linked via “meta link attributes” within the response payload; use here the following [HAL](http://stateless.co/hal_specification.html) compliant syntax:
+You should consider using a custom link relation if and only if standard [link relations](http://www.iana.org/assignments/link-relations/link-relations.xml)
+are not sufficient to express a relation.
+Related or even embedded (sub-) resources should be linked via “meta link attributes” within the response payload; use
+the following [HAL](http://stateless.co/hal_specification.html) compliant syntax:
 
     {
       ...
@@ -20,29 +54,6 @@ Related or even embedded (sub-) resources should be linked via “meta link attr
         }]
       }
     }
-
-Or the [JSON API](http://jsonapi.org/) compliant one where you also embed the entities directly:
-
-    {
-      ...
-      “relationships”: {
-        "my-entities": {
-          "data": [
-            {"id": 1, "type": "my-entity"}
-          ],
-          "links": {
-            "related": "/my-entities/123"
-          }
-        }
-      }
-    }
-
-## {{ book.should }} Use Standards for Hypermedia Link Types, HAL or JSON API recommended
-
-To represent hypermedia links in payload results, we should consider using a standard format like [HAL](http://stateless.co/hal_specification.html), [JSON API](http://jsonapi.org/), [JSON-LD](http://json-ld.org/) with [Hydra](http://www.hydra-cg.com/spec/latest/core/), or [Siren](https://github.com/kevinswiber/siren).  (Hint: Read [Kevin Sookocheff’s post](http://sookocheff.com/post/api/on-choosing-a-hypermedia-format/), for instance, to learn more about the hypermedia types.)
-
-We are in an ongoing discussion in the API guild which standard should be recommended for a certain use case. In the meantime
-we recommend to use [HAL](http://stateless.co/hal_specification.html) or [JSON API](http://jsonapi.org/).
 
 ## {{ book.should }} Allow Optional Embedding of Sub-Resources
 
@@ -58,7 +69,7 @@ See [*Conventional Query Strings*](../naming/Naming.md#could-use-conventional-qu
 Embedded resources requires to change the media type of the response accordingly:
 
 ```http
-GET /order/123?embed=(items)
+GET /order/123?embed=(items) HTTP/1.1
 Accept: application/x.order+json
 ```
 

--- a/pagination/Pagination.md
+++ b/pagination/Pagination.md
@@ -56,24 +56,36 @@ Further reading:
 * [Twitter](https://dev.twitter.com/rest/public/timelines)
 * [Use the Index, Luke](http://use-the-index-luke.com/no-offset)
 
-## {{ book.could }} Use Pagination Headers Where Applicable
+## {{ book.could }} Use Pagination Links Where Applicable
 
 * Set `X-Total-Count` to send back the total count of entities.
-* Set the [link headers](http://tools.ietf.org/html/rfc5988#section-5)
-  to provide information to the client about subsequent paging options.
+* Set links to provide information to the client about subsequent paging options.
 
 For example:
 
-    Link: <http://catalog-service.zalando.net/articles?cursor=62726863268328&limit=100>;
-          rel="next"; title="next chunk of articles"
+```http
+HTTP/1.1 200 OK
+Content-Type: application/x.zalando.products+json
+X-Total-Count: 1309
 
-or
-
-    Link: <http://catalog-service.zalando.net/articles?offset=5&limit=100>;
-          rel="prev"; title="previous chunk of articles"
-    Link: <http://catalog-service.zalando.net/articles?offset=205&limit=100>;
-          rel="next"; title="next chunk of articles"
-
+{
+  "_links": {
+    "next": {
+      "href": "http://catalog-service.zalando.net/products?offset=15&limit=5"
+    },
+    "prev": {
+      "href": "http://catalog-service.zalando.net/products?offset=5&limit=5"
+    }
+  },
+  "products": [
+    {"id": "7e4ab218-1772-11e6-892c-836df3feeaee"},
+    {"id": "9469725a-1772-11e6-83c2-ab22ac368913"},
+    {"id": "a3625d80-1772-11e6-9213-d3a20f9e6bf4"},
+    {"id": "a802f070-1772-11e6-a772-c3020d55eb5f"},
+    {"id": "adb407ac-1772-11e6-b255-078fb28ff55b"}
+  ]
+}
+```
 
 [Possible relations](http://www.iana.org/assignments/link-relations/link-relations.xml):
 `next`, `prev`, `last`, `first`


### PR DESCRIPTION
Fixes #24 
Fixes #54 

- deprecated Link headers
- favored HAL over other standards
- added hypermedia format comparison