### PR TITLE
Fix wrong formatting of Common Data Objects headline

### DIFF
--- a/common-data-objects/CommonDataObjects.md
+++ b/common-data-objects/CommonDataObjects.md
@@ -1,4 +1,4 @@
-﻿# Common Data Objects
+# Common Data Objects
 
 Definitions of data objects that are good candidates for wider usage:
 


### PR DESCRIPTION
For some unknown reason headline of common data objects is not formatted in http://zalando.github.io/restful-api-guidelines/common-data-objects/CommonDataObjects.html

This change will fix it.