### PR TITLE
Guidance on 429 responses and Rate Limits.

### DIFF
--- a/http/Http.md
+++ b/http/Http.md
@@ -150,6 +150,6 @@ The 'X-RateLimit' headers are:
 
 - `X-RateLimit-Limit`: The maximum number of requests that the client is allowed to make in this window.
 - `X-RateLimit-Remaining`: The number of requests allowed in the current window.
-- `X-RateLimit-Reset`: The time at which the current rate limit window will be reset in seconds as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
+- `X-RateLimit-Reset`: The relative time in seconds when the rate limit window will be reset.
 
 The reason to allow both approaches is that APIs can have different needs. Retry-After is often sufficient for general load handling and request throttling scenarios and notably, does not strictly require the concept of a calling entity such as a tenant or named account. In turn this allows resource owners to minimise the amount of state they have to carry with respect to client requests. The 'X-RateLimit' headers are suitable for scenarios where clients are associated with pre-existing account or tenancy structures. 'X-RateLimit' headers are generally returned on every request and not just on a 429, which implies the service implementing the API is carrying sufficient state to track the number of requests made within a given window for each named entity.

--- a/http/Http.md
+++ b/http/Http.md
@@ -119,7 +119,7 @@ different HTTP methods on resources.
 | 422 | Unprocessable Entity - semantic error (as opposed to a syntax error which would usually trigger a 400) | POST, PUT, DELETE, PATCH |
 | 423 | Locked - Pessimistic locking, e.g. processing states | PUT, DELETE, PATCH |
 | 428 | Precondition Required - server requires the request to be conditional (e.g. to make sure that the “lost update problem” is avoided). | All |
-| 429 | Too many requests - the client does not consider rate limiting and sent too many requests | All |
+| 429 | Too many requests - the client does not consider rate limiting and sent too many requests. See ["Use 429 with Headers for Rate Limits"](#must-use-429-with-headers-for-rate-limits). | All |
 
 ###Server Side Error Codes:
 
@@ -137,3 +137,19 @@ APIs should define the functional, business view and abstract from implementatio
 
 The OpenAPI specification shall include definitions for error descriptions that will be returned; they are part of the interface definition and provide important information for service clients to handle exceptional situations and support troubleshooting. You should also think about a troubleshooting board — it is part of the associated online API documentation, provides information and handling guidance on application-specific errors and is referenced via links of the API definition. This can reduce service support tasks and contribute to service client and provider performance.
 
+
+## {{ book.must }} Use 429 with Headers for Rate Limits
+
+APIs that wish to manage the request rate of clients must use the ['429 Too Many Requests'](http://tools.ietf.org/html/rfc6585) response code if the client exceeded the request rate and therefore the request can't be fulfilled. Such responses must also contain header information providing further details to the client. There are two approaches a service can take for header information:
+
+ - Return a ['Retry-After'](https://tools.ietf.org/html/rfc7231#section-7.1.3) header indicating how long the client ought to wait before making a follow-up request. The Retry-After header can contain a HTTP date value to retry after or the number of seconds to delay. Either is acceptable but APIs should prefer to use a delay in seconds.
+ 
+ - Return a trio of 'X-RateLimit' headers. These headers (described below) allow a server to express a service level in the form of a number of allowing requests within a given window of time and when the window is reset. 
+
+The 'X-RateLimit' headers are:
+
+- `X-RateLimit-Limit`: The maximum number of requests that the client is allowed to make in this window.
+- `X-RateLimit-Remaining`: The number of requests allowed in the current window.
+- `X-RateLimit-Reset`: The time at which the current rate limit window will be reset in seconds as a [Unix timestamp](http://en.wikipedia.org/wiki/Unix_time).
+
+The reason to allow both approaches is that APIs can have different needs. Retry-After is often sufficient for general load handling and request throttling scenarios and notably, does not strictly require the concept of a calling entity such as a tenant or named account. In turn this allows resource owners to minimise the amount of state they have to carry with respect to client requests. The 'X-RateLimit' headers are suitable for scenarios where clients are associated with pre-existing account or tenancy structures. 'X-RateLimit' headers are generally returned on every request and not just on a 429, which implies the service implementing the API is carrying sufficient state to track the number of requests made within a given window for each named entity.


### PR DESCRIPTION
Describe options to use 'Retry-After' or 'X-RateLimit headers
in conjunction with a '429 Too Many Requests' response.

For #77

/ @bocytko @conorclifford @tlossen  @whiskeysierra