### PR TITLE
Fix link pointing to wrong chapter

### DIFF
--- a/naming/Naming.md
+++ b/naming/Naming.md
@@ -66,7 +66,7 @@ following standardized naming conventions:
   Hint: In combination with limit, you can use page as an alternative to offset.
 * `sort` — comma-separated list of fields to sort. To indicate sorting direction,
   fields my prefixed with + (ascending) or - (descending, default), e.g. /sales-orders?sort=+id
-* `fields` — to retrieve a subset of fields. See [*Support Filtering of Resource Fields*](../http/Http.md#should-support-filtering-of-resource-fields) below.
+* `fields` — to retrieve a subset of fields. See [*Support Filtering of Resource Fields*](../performance/Performance.html#should-support-filtering-of-resource-fields) below.
 * `embed` — to expand embedded entities (ie.: inside of an article entity, expand silhouette code
   into the silhouette object). Implementing “expand” correctly is difficult, so do it with care. See
   [*Embedding resources*](../hyper-media/Hypermedia.md#should-allow-embedding-of-complex-subresources) for more details.

--- a/naming/Naming.md
+++ b/naming/Naming.md
@@ -66,7 +66,7 @@ following standardized naming conventions:
   Hint: In combination with limit, you can use page as an alternative to offset.
 * `sort` — comma-separated list of fields to sort. To indicate sorting direction,
   fields my prefixed with + (ascending) or - (descending, default), e.g. /sales-orders?sort=+id
-* `fields` — to retrieve a subset of fields. See [*Support Filtering of Resource Fields*](../performance/Performance.html#should-support-filtering-of-resource-fields) below.
+* `fields` — to retrieve a subset of fields. See [*Support Filtering of Resource Fields*](../performance/Performance.md#should-support-filtering-of-resource-fields) below.
 * `embed` — to expand embedded entities (ie.: inside of an article entity, expand silhouette code
   into the silhouette object). Implementing “expand” correctly is difficult, so do it with care. See
   [*Embedding resources*](../hyper-media/Hypermedia.md#should-allow-embedding-of-complex-subresources) for more details.


### PR DESCRIPTION
Support Filtering of Resource Fields link repaired.
  
Naming section **Could: Use Conventional Query Strings** has a link for filtering pointing the wrong location,
