### PR TITLE
Added common pattern must to deprecation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ serve: | $(gitbook)
 	$(gitbook) serve
 
 build: | $(gitbook)
-	$(gitbook) build
+	$(gitbook) build -v 2.6.7
 
 publish: build | $(gh_pages)
 	$(gh_pages) -d _book

--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -143,22 +143,3 @@ are still under review; for example:
 Hint: This versioning scheme differs in the less strict DRAFT aspect from
 [semantic version information](http://semver.org) used for released APIs and
 service applications.
-
-## {{ book.must }} If Neccessary Declare Deprecation
-
-Sometimes it is necessary to phase out an API endpoint (or version). I.e. this may be necessary if a field is no longer supported in the result or a whole business functionality behind an endpoint has to be shut down. There are multiple other reasons as well.
-
-Before shutting down an API (or version of an API) the producer must make sure, that all clients have given their consent to shut down the endpoint. Producers should help consumers to migrate to a potential new endpoint (i.e. by providing a migration manual). After all clients are migrated, the producer may shut down the deprecated API.
-
-API deprecation must reflect in the producers OpenAPI definition. If a method on a path, a whole path or even a whole API endpoint (multiple paths) should be deprecated, the producers must set `deprecated=true` on each method / path element that will be deprecated (OpenAPI 2.0 only allows you to define deprecation on this level). If deprecation should happen on a finer level (i.e. query parameter, payload etc.), the producer should set `deprecated=true` on the affected method / path element and add further explanation to the `description` section.
-If `deprecated` is set to `true`, the producer must describe what clients should use instead and when the API will be shut down in the `description` section of the API definition.
-
-During deprecation phase, the producer should add a `Warning` header (see [RFC 7234 - Warning header](https://tools.ietf.org/html/rfc7234#section-5.5)) field. When adding the `Warning` header, the `warn-code` must be `299` and the `warn-text` should be in form of *"The path/operation/parameter/... {name} is deprecated and will be removed by {date}. Please see {link} for details."* with a link to a documentation describing why the API is no longer supported in the current form and what clients should do about it. Clients should monitor the `Warning` header in HTTP responses. Adding the `Warning` header is not sufficient to gain client consent to shut down an API.
-
-If the API is consumed by any external partner, the producer must define a reasonable timespan that the API will be maintained after the producer has announced deprecation. The external partner (client) must agree to this minimum after-deprecation-lifespan before he starts using the API.
-
-## {{ book.must }} Clients Must Not Start Using Deprecated API Parts
-
-Clients must not start using deprecated parts of an API.
-
-## {{ book.should }} producers should monitor usage of those APIs.

--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -148,10 +148,12 @@ service applications.
 
 Sometimes it is necessary to phase out an API endpoint (or version). I.E. this may be necessary if a field is no longer supported in the result or a whole business functionality behind an endpoint has to be shut down. There are multiple other reasons as well.
 
-First of all the provider must make sure, that there is no downwards compatible way to maintain the API any longer.
-
 Before shutting down an API (or version of an API) the producer must make sure, that all clients have given their consent to shut down the endpoint. Producers should help consumers to migrate to a potential new endpoint (i.e. by providing a migration manual). After all clients are migrated, the producer may shut down the deprecated API.
 
-During deprecation phase, the producer should add a `Warning` header (see [RFC 7234 - Warning header](https://tools.ietf.org/html/rfc7234#section-5.5)) field. When adding the `Warning` header, the `warn-code` must be `299` and the `warn-text` should be in form of *"The path/operation/parameter/... {name} is deprecated and will be removed by {date}. Please see {link} for details."* with a link to a documantation describing why the API is no longer supported in the current form and what clients should do about it. Clients should monitor the `Warning` header in HTTP responses. Adding the `Warning` header is no sufficient to gain client consent to shut down an API.
+Producers must document API deprecation setting deprecated=true on path / operation level in the Swagger API definition and add guidelines what clients should use instead and when the API will be shut down to the description field. Clients must not start using deprecated APIs.
+
+During deprecation phase, the producer should add a `Warning` header (see [RFC 7234 - Warning header](https://tools.ietf.org/html/rfc7234#section-5.5)) field. When adding the `Warning` header, the `warn-code` must be `299` and the `warn-text` should be in form of *"The path/operation/parameter/... {name} is deprecated and will be removed by {date}. Please see {link} for details."* with a link to a documentation describing why the API is no longer supported in the current form and what clients should do about it. Clients should monitor the `Warning` header in HTTP responses. Adding the `Warning` header is not sufficient to gain client consent to shut down an API.
+
+Producers should monitor usage of a deprecated API.
 
 If the API is consumed by any external partner, the producer must define a reasonable timespan that the API will be maintained after the producer has announced deprecation. The external partner (client) must agree to this minimum after-deprecation-lifespan before he starts using the API.

--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -146,14 +146,15 @@ service applications.
 
 ## Deprecating an API
 
-Sometimes it is necessary to phase out an API endpoint (or version). I.E. this may be necessary if a field is no longer supported in the result or a whole business functionality behind an endpoint has to be shut down. There are multiple other reasons as well.
+Sometimes it is necessary to phase out an API endpoint (or version). I.e. this may be necessary if a field is no longer supported in the result or a whole business functionality behind an endpoint has to be shut down. There are multiple other reasons as well.
 
 Before shutting down an API (or version of an API) the producer must make sure, that all clients have given their consent to shut down the endpoint. Producers should help consumers to migrate to a potential new endpoint (i.e. by providing a migration manual). After all clients are migrated, the producer may shut down the deprecated API.
 
-Producers must document API deprecation setting deprecated=true on path / operation level in the Swagger API definition and add guidelines what clients should use instead and when the API will be shut down to the description field. Clients must not start using deprecated APIs.
+API deprecation must reflect in the producers OpenAPI definition. If a method on a path, a whole path or even a whole API endpoint (multiple paths) should be deprecated, the producers must set `deprecated=true` on each method / path element that will be deprecated (OpenAPI 2.0 only allows you to define deprecation on this level). If deprecation should happen on a finer level (i.e. query parameter, payload etc.), the producer should set `deprecated=true` on the affected method / path element and add further explanation to the `description` section.
+If `deprecated` is set to `true`, the producer must describe what clients should use instead and when the API will be shut down in the `description` section of the API definition.
+
+Clients must not start using deprecated parts of an API and producers should monitor usage of those APIs.
 
 During deprecation phase, the producer should add a `Warning` header (see [RFC 7234 - Warning header](https://tools.ietf.org/html/rfc7234#section-5.5)) field. When adding the `Warning` header, the `warn-code` must be `299` and the `warn-text` should be in form of *"The path/operation/parameter/... {name} is deprecated and will be removed by {date}. Please see {link} for details."* with a link to a documentation describing why the API is no longer supported in the current form and what clients should do about it. Clients should monitor the `Warning` header in HTTP responses. Adding the `Warning` header is not sufficient to gain client consent to shut down an API.
-
-Producers should monitor usage of a deprecated API.
 
 If the API is consumed by any external partner, the producer must define a reasonable timespan that the API will be maintained after the producer has announced deprecation. The external partner (client) must agree to this minimum after-deprecation-lifespan before he starts using the API.

--- a/deprecation/Deprecation.md
+++ b/deprecation/Deprecation.md
@@ -3,7 +3,7 @@
 Sometimes it is necessary to phase out an API endpoint (or version). I.e. this
 may be necessary if a field is no longer supported in the result or a whole
 business functionality behind an endpoint has to be shut down. There are
-multiple other reasons as well.
+many other reasons as well.
 
 
 ## {{ book.must }} Obtain Approval of Clients
@@ -14,7 +14,7 @@ endpoint. Producers should help consumers to migrate to a potential new
 endpoint (i.e. by providing a migration manual). After all clients are
 migrated, the producer may shut down the deprecated API.
 
-## {{ book.must }} External Partners Must Agree on Lifecycle Timespans
+## {{ book.must }} External Partners Must Agree on Deprecation Timespan
 
 If the API is consumed by any external partner, the producer must define a
 reasonable timespan that the API will be maintained after the producer has
@@ -23,12 +23,12 @@ minimum after-deprecation-lifespan before he starts using the API.
 
 ## {{ book.must }} Reflect Deprecation in API Definition
 
-API deprecation must reflect in the producers OpenAPI definition. If a method
+API deprecation must be part of the OpenAPI definition. If a method
 on a path, a whole path or even a whole API endpoint (multiple paths) should
 be deprecated, the producers must set `deprecated=true` on each method / path
 element that will be deprecated (OpenAPI 2.0 only allows you to define
-deprecation on this level). If deprecation should happen on a finer level
-(i.e. query parameter, payload etc.), the producer should set
+deprecation on this level). If deprecation should happen on a more fine grained 
+level (i.e. query parameter, payload etc.), the producer should set
 `deprecated=true` on the affected method / path element and add further
 explanation to the `description` section. 
 
@@ -53,7 +53,7 @@ header is not sufficient to gain client consent to shut down an API.
 
 ## {{ book.should }} Add Monitoring for Warning Header
 
-Clients should monitor the `Warning` header in HTTP responses.
+Clients should monitor the `Warning` header in HTTP responses to see if an API will be deprecated in future.
 
 ## {{ book.must }} Not Start Using Deprecated APIs
 

--- a/deprecation/Deprecation.md
+++ b/deprecation/Deprecation.md
@@ -38,7 +38,7 @@ section of the API definition.
 
 ## {{ book.should }} Monitor Usage of Deprecated APIs
 
-Producers should monitor usage of deprecated APIs.
+Producers should monitor usage of deprecated APIs until it the API can be shut down.
 
 ## {{ book.should }} Add a Warning Header to Responses
 


### PR DESCRIPTION
> After the last API guild meeting, I'm unsure, if we should keep the paragraph like this or change it to the MUST/SHOULD headline style. What do you think? (@codekultur  #91)

How is the opinion of the others?