### PR TITLE
removed duplicate deprecation paragraph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "5.1"
 
 before_install:
-  - sudo -v && wget --no-check-certificate -nv -O- https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py | sudo python -c "import sys; main=lambda:sys.stderr.write('Download failed\n'); exec(sys.stdin.read()); main(install_dir='/usr/local')"
+  - sudo -v && wget -nv -O- https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py | sudo python -c "import sys; main=lambda:sys.stderr.write('Download failed\n'); exec(sys.stdin.read()); main(install_dir='/usr/local')"
 
 script:
   - gitbook build -v 2.6.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "5.1"
 
 before_install:
-  - sudo -v && wget -nv -O- https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py | sudo python -c "import sys; main=lambda:sys.stderr.write('Download failed\n'); exec(sys.stdin.read()); main(install_dir='/usr/local')"
+  - sudo -v && wget --no-check-certificate -nv -O- https://raw.githubusercontent.com/kovidgoyal/calibre/master/setup/linux-installer.py | sudo python -c "import sys; main=lambda:sys.stderr.write('Download failed\n'); exec(sys.stdin.read()); main(install_dir='/usr/local')"
 
 script:
   - gitbook build -v 2.6.7

--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -143,18 +143,3 @@ are still under review; for example:
 Hint: This versioning scheme differs in the less strict DRAFT aspect from
 [semantic version information](http://semver.org) used for released APIs and
 service applications.
-
-## Deprecating an API
-
-Sometimes it is necessary to phase out an API endpoint (or version). I.e. this may be necessary if a field is no longer supported in the result or a whole business functionality behind an endpoint has to be shut down. There are multiple other reasons as well.
-
-Before shutting down an API (or version of an API) the producer must make sure, that all clients have given their consent to shut down the endpoint. Producers should help consumers to migrate to a potential new endpoint (i.e. by providing a migration manual). After all clients are migrated, the producer may shut down the deprecated API.
-
-API deprecation must reflect in the producers OpenAPI definition. If a method on a path, a whole path or even a whole API endpoint (multiple paths) should be deprecated, the producers must set `deprecated=true` on each method / path element that will be deprecated (OpenAPI 2.0 only allows you to define deprecation on this level). If deprecation should happen on a finer level (i.e. query parameter, payload etc.), the producer should set `deprecated=true` on the affected method / path element and add further explanation to the `description` section.
-If `deprecated` is set to `true`, the producer must describe what clients should use instead and when the API will be shut down in the `description` section of the API definition.
-
-Clients must not start using deprecated parts of an API and producers should monitor usage of those APIs.
-
-During deprecation phase, the producer should add a `Warning` header (see [RFC 7234 - Warning header](https://tools.ietf.org/html/rfc7234#section-5.5)) field. When adding the `Warning` header, the `warn-code` must be `299` and the `warn-text` should be in form of *"The path/operation/parameter/... {name} is deprecated and will be removed by {date}. Please see {link} for details."* with a link to a documentation describing why the API is no longer supported in the current form and what clients should do about it. Clients should monitor the `Warning` header in HTTP responses. Adding the `Warning` header is not sufficient to gain client consent to shut down an API.
-
-If the API is consumed by any external partner, the producer must define a reasonable timespan that the API will be maintained after the producer has announced deprecation. The external partner (client) must agree to this minimum after-deprecation-lifespan before he starts using the API.


### PR DESCRIPTION
Not sure how this happened: By accident the merge for the API deprecation as a separate chapter didn't have the commit in it which removed the API deprecation paragraph from the Compatibility chapter... This PR should fix the duplicate deprecation paragraph... 