### PR TITLE
added rule to always return objects, no arrays

### DIFF
--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -49,7 +49,7 @@ How to do this:
 * Be prepared to handle HTTP status codes not explicitly specified in endpoint definitions! Note also, that status codes are extensible -- default handling is how you would treat the corresponding x00 code (see [RFC7231  Section 6](https://tools.ietf.org/html/rfc7231#section-6))
 
 ## {{book.must}} Always Return JSON Objects As Top-Level Data Structures To Support Extensibility
-In a response body, you must always return a JSON objects (and not i.e. arrays) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and i.e. add pagination later, without breaking the API.
+In a response body, you must always return a JSON objects (and not i.e. an array) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and i.e. add pagination later, without breaking the API.
 
 ## {{ book.should }} Avoid Versioning
 

--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -48,6 +48,9 @@ How to do this:
 * Follow the redirect when the server returns an “HTTP 301 Moved Permanently” response code
 * Be prepared to handle HTTP status codes not explicitly specified in endpoint definitions! Note also, that status codes are extensible -- default handling is how you would treat the corresponding x00 code (see [RFC7231  Section 6](https://tools.ietf.org/html/rfc7231#section-6))
 
+## {{book.must}} Always Return JSON Objects As Top-Level Data Structures To Support Extensibility
+In a response body, you must always return a JSON objects (and not i.e. arrays) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and i.e. add pagination later, without breaking the API.
+
 ## {{ book.should }} Avoid Versioning
 
 When changing your RESTful APIs,

--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -49,7 +49,7 @@ How to do this:
 * Be prepared to handle HTTP status codes not explicitly specified in endpoint definitions! Note also, that status codes are extensible -- default handling is how you would treat the corresponding x00 code (see [RFC7231  Section 6](https://tools.ietf.org/html/rfc7231#section-6))
 
 ## {{book.must}} Always Return JSON Objects As Top-Level Data Structures To Support Extensibility
-In a response body, you must always return a JSON objects (and not i.e. an array) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and i.e. add pagination later, without breaking backwards compatibility.
+In a response body, you must always return a JSON objects (and not e.g. an array) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and i.e. add pagination later, without breaking backwards compatibility.
 
 ## {{ book.should }} Avoid Versioning
 

--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -49,7 +49,7 @@ How to do this:
 * Be prepared to handle HTTP status codes not explicitly specified in endpoint definitions! Note also, that status codes are extensible -- default handling is how you would treat the corresponding x00 code (see [RFC7231  Section 6](https://tools.ietf.org/html/rfc7231#section-6))
 
 ## {{book.must}} Always Return JSON Objects As Top-Level Data Structures To Support Extensibility
-In a response body, you must always return a JSON objects (and not e.g. an array) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and i.e. add pagination later, without breaking backwards compatibility.
+In a response body, you must always return a JSON objects (and not e.g. an array) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and e.g. add pagination later, without breaking backwards compatibility.
 
 ## {{ book.should }} Avoid Versioning
 

--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -49,7 +49,7 @@ How to do this:
 * Be prepared to handle HTTP status codes not explicitly specified in endpoint definitions! Note also, that status codes are extensible -- default handling is how you would treat the corresponding x00 code (see [RFC7231  Section 6](https://tools.ietf.org/html/rfc7231#section-6))
 
 ## {{book.must}} Always Return JSON Objects As Top-Level Data Structures To Support Extensibility
-In a response body, you must always return a JSON objects (and not i.e. an array) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and i.e. add pagination later, without breaking the API.
+In a response body, you must always return a JSON objects (and not i.e. an array) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and i.e. add pagination later, without breaking backwards compatibility.
 
 ## {{ book.should }} Avoid Versioning
 

--- a/pagination/Pagination.md
+++ b/pagination/Pagination.md
@@ -1,5 +1,8 @@
 # Pagination
 
+## {{book.must}} Always Return JSON Objects To Support Future Pagination
+When returning a collection, you must always return a JSON object (and not i.e. an array). This holds true for all collections. If you need to add pagination later, you can easily do so by extending the JSON object without breaking the API.
+
 ## {{ book.must }} Support Pagination
 
 Access to lists of data items must support pagination for best client side batch processing and iteration experience. This holds true for all lists that are (potentially) larger than just a

--- a/pagination/Pagination.md
+++ b/pagination/Pagination.md
@@ -1,7 +1,7 @@
 # Pagination
 
-## {{book.must}} Always Return JSON Objects To Support Future Pagination
-When returning a collection, you must always return a JSON object (and not i.e. an array). This holds true for all collections. If you need to add pagination later, you can easily do so by extending the JSON object without breaking the API.
+## {{book.must}} Always Return JSON Objects To Support Extensibility
+When returning a collection, you must always return a JSON object (and not i.e. an array). This holds true for all collections. JSON objects support compatible extension by additional attributes. This way you can easily add pagination later, without breaking the API.
 
 ## {{ book.must }} Support Pagination
 

--- a/pagination/Pagination.md
+++ b/pagination/Pagination.md
@@ -1,8 +1,5 @@
 # Pagination
 
-## {{book.must}} Always Return JSON Objects To Support Extensibility
-When returning a collection, you must always return a JSON object (and not i.e. an array). This holds true for all collections. JSON objects support compatible extension by additional attributes. This way you can easily add pagination later, without breaking the API.
-
 ## {{ book.must }} Support Pagination
 
 Access to lists of data items must support pagination for best client side batch processing and iteration experience. This holds true for all lists that are (potentially) larger than just a


### PR DESCRIPTION
https://github.com/zalando/restful-api-guidelines/issues/117

I was not sure where to put it. Feedback welcome..