### PR TITLE
Improved explanation of embedding sub-resources

### DIFF
--- a/hyper-media/Hypermedia.md
+++ b/hyper-media/Hypermedia.md
@@ -76,7 +76,7 @@ We opted for this subset of HAL after conducting a comparison of different hyper
 | [Siren](https://github.com/kevinswiber/siren)                  | ✗          | ✗             | ✗        | Entities and navigation | ✗    |
 | [Collection+JSON](http://amundsen.com/media-types/collection/) | ✗          | ✗             | ✗        | Collections and queries | ✓    |
 
-We define HAL links to be extensible, i.e. to contain additional properties if needed. For consistency extensions should reuse attributes from the [`Link` header](https://tools.ietf.org/html/rfc5988#section-5). 
+We define HAL links to be extensible, i.e. to contain additional properties if needed. For consistency extensions should reuse attributes from the [`Link` header](https://tools.ietf.org/html/rfc5988#section-5).
 
 Interesting articles for comparisons of different hypermedia formats:
 * [Kevin Sookocheff’s On choosing a hypermedia type for your API](http://sookocheff.com/post/api/on-choosing-a-hypermedia-format/)
@@ -98,34 +98,11 @@ the following [HAL](http://stateless.co/hal_specification.html) compliant syntax
     {
       ...
       “_links”: {
-        “my-entity”: {
+        “my-relation”: {
           “href”: “https://service.team.zalan.do/my-entities/123”
         }
       }
     }
 
 In earlier versions of this rule we proposed URIs but dropped that in favor of readability. Since link relations are
-properties in the `_links` object you should define and describe them individually in the API specification. 
-
-## {{ book.should }} Allow Optional Embedding of Sub-Resources
-
-Embedding related resources (also know as *Resource expansion*) is a great way to reduce the number of requests. In
-cases where clients know upfront that they need some related resources they can instruct the server to prefetch that
-data eagerly. Whether this is optimized on the server, e.g. a database join, or done in a generic way, e.g. an HTTP
-proxy that transparently embeds resources, is up to the implementation.
-
-See [*Conventional Query Strings*](../naming/Naming.md#could-use-conventional-query-strings) for naming.
-
-## {{ book.must}} Modify the Content-Type for Embedded Resources
-
-Embedded resources requires to change the media type of the response accordingly:
-
-```http
-GET /order/123?embed=(items) HTTP/1.1
-Accept: application/x.order+json
-```
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/x.order+json;embed=(items)
-```
+properties in the `_links` object you should define and describe them individually in the API specification.

--- a/performance/Performance.md
+++ b/performance/Performance.md
@@ -116,16 +116,18 @@ Embedding a sub-resource can possibly look like this where an order resource has
 GET /order/123?embed=(items) HTTP/1.1
 
 {
-  "orderId": 123,
-  "items": [
-    {
-      "position": 1,
-      "sku": "1234-ABCD-7890",
-      "price": {
-        "amount": 71.99,
-        "currency": "EUR"
+  "id": "123",
+  "_embedded": {
+    "items": [
+      {
+        "position": 1,
+        "sku": "1234-ABCD-7890",
+        "price": {
+          "amount": 71.99,
+          "currency": "EUR"
+        }
       }
-    }
-  ]
+    ]
+  }
 }
 ```

--- a/performance/Performance.md
+++ b/performance/Performance.md
@@ -98,5 +98,34 @@ Its possible contents:
 * hash of the response body
 * hash of the entity’s last modified field
 
-Also see [*Allow Embedding of Complex Sub-Resources*](../hyper-media/Hypermedia.md#should-allow-embedding-of-complex-subresources)
-below as contribution to performance optimization as to avoid multiple requests for sub-resources.
+Also see [*Allow Embedding of Complex Sub-Resources*](../performance/Performance.md#should-allow-embedding-of-complex-subresources)
+below as contribution to performance optimization to avoid multiple requests for sub-resources.
+
+## {{ book.should }} Allow Optional Embedding of Sub-Resources
+
+Embedding related resources (also know as *Resource expansion*) is a great way to reduce the number of requests. In
+cases where clients know upfront that they need some related resources they can instruct the server to prefetch that
+data eagerly. Whether this is optimized on the server, e.g. a database join, or done in a generic way, e.g. an HTTP
+proxy that transparently embeds resources, is up to the implementation.
+
+See [*Conventional Query Strings*](../naming/Naming.md#could-use-conventional-query-strings) for naming. Please use [json-fields](https://github.com/zalando/json-fields) library, already mentioned above for filtering, when it comes to an embedding query syntax.
+
+Embedding a sub-resource can possibly look like this where an order resource has its order items as sub-resource (/order/{orderId}/items):
+
+```http
+GET /order/123?embed=(items) HTTP/1.1
+
+{
+  "orderId": 123,
+  "items": [
+    {
+      "position": 1,
+      "sku": "1234-ABCD-7890",
+      "price": {
+        "amount": 71.99,
+        "currency": "EUR"
+      }
+    }
+  ]
+}
+```


### PR DESCRIPTION
This PR does the following:
- moved embedding to performance chapter
- removed custom media type for embedding
- added link to json-field (to make embedding symmetric to filtering)
- added example for embedding

Fixes #67 