### PR TITLE
Added changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,6 @@
 **DON'T** push to the master branch directly. Always use pull requests and let people discuss changes in pull request.
 
 Pull requests should only be merged after all discussions have been concluded and at least 2 reviewers gave their approvals.
+
+## Changelog for major changes
+When your pull request does major changes, please also add an entry to the changelog.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,5 @@
 # Summary
 
-* [Introduction](README.md)
 * [Table of Contents](TOC.md)
 * [Design Principles](design-principles/DesignPrinciples.md)
 * [General Guidelines](general-guidelines/GeneralGuidelines.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,5 +1,6 @@
 # Summary
 
+* [Introduction](README.md)
 * [Table of Contents](TOC.md)
 * [Design Principles](design-principles/DesignPrinciples.md)
 * [General Guidelines](general-guidelines/GeneralGuidelines.md)
@@ -21,3 +22,4 @@
 * [Events](events/events.md)
 * [References](references/References.md)
 * [Tooling](tooling/Tooling.md)
+* [Changelog](changelog/Changelog.md)

--- a/changelog/Changelog.md
+++ b/changelog/Changelog.md
@@ -1,3 +1,11 @@
 #Changelog
 
-* `2016-10-10:` Introduced the changelog. From now on all changes on API guidelines will be recorded here.
+This change log only contains major changes made after October 2016.
+
+Non-major changes are editorial-only changes or minor changes of existing guidelines, e.g. adding new error code. Major changes are changes that come with additional obligations, or even change an existing guideline obligation. The latter changes are additionally labelled with "Rule Change" here.
+
+To see a list of all changes, please have a look at the [commit list in Github](https://github.com/zalando/restful-api-guidelines/commits/master).
+
+## Rule Changes
+
+* `2016-10-10:` Introduced the changelog. From now on all rule changes on API guidelines will be recorded here.

--- a/changelog/Changelog.md
+++ b/changelog/Changelog.md
@@ -1,0 +1,3 @@
+#Changelog
+
+* `2016-10-10:` Introduced the changelog. From now on all changes on API guidelines will be recorded here.


### PR DESCRIPTION
As discussed in the last API guild meeting and stated in https://github.com/zalando/restful-api-guidelines/issues/139 we like to introduce a changelog for API guideline changes. This is a first shot...