### PR TITLE
Treat Open API Definitions As Open For Extension By Default.

### DIFF
--- a/compatibility/Compatibility.md
+++ b/compatibility/Compatibility.md
@@ -54,6 +54,35 @@ How to do this:
 
 In a response body, you must always return a JSON objects (and not e.g. an array) as a top level data structure to support future extensibility. JSON objects support compatible extension by additional attributes. This allows you to easily extend your response and e.g. add pagination later, without breaking backwards compatibility.
 
+## {{ book.must }} Treat Open API Definitions As Open For Extension By Default
+
+The Open API 2.0 specification is not very specific on default extensibility 
+of objects, and redefines JSON-Schema keywords related to extensibility, like 
+`additionalProperties`. Following our overall compatibility guidelines, Open 
+API object definitions are considered open for extension by default as per 
+[Section 5.18 "additionalProperties"](http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.18) of JSON-Schema. 
+
+When it comes to Open API 2.0, this means an `additionalProperties` declaration 
+is not required to make an object definition extensible:
+
+- API clients consuming data must not assume that objects are closed for 
+  extension in the absence of an `additionalProperties` declaration and must 
+  ignore fields sent by the server they cannot process. This allows API servers 
+  to evolve their data formats. 
+
+- For API servers receiving unxpected data, the situation is slightly different. 
+ Instead of ignoring fields, servers _may_ reject requests whose entities 
+ contain undefined fields in order to signal to clients that those fields 
+ would not be stored on behalf of the client. API designers must document 
+ clearly how unexpected fields are handled for PUT, POST and PATCH requests. 
+
+API formats must not declare `additionalProperties` to be false, as this 
+prevents objects being extended in the future.
+
+Note  that this guideline concentrates on default extensibility and does not 
+exclude the use of `additionalProperties` with a schema as a value, which might 
+be appropriate in some circumstances.
+
 ## {{ book.should }} Used Open-Ended List of Values (x-extensible-enum) Instead of Enumerations
 
 Enumerations are per definition closed sets of values, that are assumed to be complete and not

--- a/events/events.md
+++ b/events/events.md
@@ -136,6 +136,43 @@ These are considered backwards-incompatible changes, as seen by consumers  -
 - Adding a new optional field to redefine the meaning of an existing field (also known as a co-occurrence constraint).
 - Adding a value to an enumeration (note that [`x-extensible-enum`](../compatibility/Compatibility.md#should-used-openended-list-of-values-xextensibleenum-instead-of-enumerations) is not available in JSON Schema).
 
+## {{ book.should }} Avoid `additionalProperties` in event type definitions
+
+Event type schema should avoid using `additionalProperties` declarations, in 
+order to support schema evolution.
+
+Events are often intermediated by publish/subscribe systems and are 
+commonly captured in logs or long term storage to be read later. In 
+particular, the schemas used by publishers and consumers can  
+drift over time. As a result, compatibility and extensibility issues 
+that happen less frequently with client-server style APIs become important 
+and regular considerations for event design. The guidelines recommend the 
+following to enable event schema evolution:
+
+- Publishers who intend to provide compatibility and allow their schemas 
+  to evolve safely over time must define new optional fields 
+  (as additive changes) and update their schemas in advance of publishing 
+  those fields. In doing so, they **must not** declare an `additionalProperties` 
+  field as a wildcard extension point. 
+
+- Consumers must ignore fields they cannot process and not raise 
+  errors, just as they would as an API client. This can happen if they are 
+  processing events with an older copy of the event schema than the one
+  containing the new definitions specified by the publishers. 
+
+Requiring event publishers to define their fields ahead of publishing avoids 
+the problem of _field redefinition_. This is when a publisher defines a 
+field to be of a different type that was already being emitted, or, is 
+changing the type of an undefined field. Both of these are prevented by 
+not using `additionalProperties`. 
+
+Avoiding `additionalProperties` as described here also aligns with the approach
+ taken by the Nakadi API's ["compatible mode"](http://zalando.github.io/nakadi-manual/docs/using/event-types.html#compatible) for event type schema.
+
+See also "Treat Open API Definitions As Open For Extension By Default"  
+in the [Compatibility](../compatibility/Compatibility.md#must-treat-open-api-definitions-as-open-for-extension-by-default) 
+section for further guidelines on the use of `additionalProperties`. 
+
 ## {{ book.must }} Use unique Event identifiers
 
 The `eid` (event identifier) value of an event must be unique.


### PR DESCRIPTION
This guideline covers a major gap in the Open API v2.0 specification
around default extensibility, along with recommendation for using
additionalProperties in client-server APIs and event definitions.

for #164