### PR TITLE
Uses RFC2119 keywords to indicate guidance levels.

### DIFF
--- a/Introduction.md
+++ b/Introduction.md
@@ -25,6 +25,10 @@ We encourage our teams to follow them to ensure that our APIs:
 
 Ideally, all Zalando APIs will look like the same author created them.
 
+## Conventions Used in These Guidelines
+
+The requirement level keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" used in this document (case insensitive) are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
 ## Zalando specific information
 
 The purpose of our “RESTful API guidelines” is to define standards to successfully establish

--- a/book.json
+++ b/book.json
@@ -4,7 +4,7 @@
   },
   "variables": {
     "should": "<span style=\"color:darkgoldenrod;font-weight:bold\">Should:</span>",
-    "could": "<span style=\"color:green;font-weight:bold\">Could:</span>",
+    "may": "<span style=\"color:green;font-weight:bold\">May:</span>",
     "must": "<span style=\"color:red;font-weight:bold\">Must:</span>"
   },
   "plugins": [

--- a/changelog/Changelog.md
+++ b/changelog/Changelog.md
@@ -8,6 +8,8 @@ To see a list of all changes, please have a look at the [commit list in Github](
 
 ## Rule Changes
 
+* `2017-05-10:` Added the convention of using RFC2119 to describe guideline 
+levels, and replaced `book.could` with `book.may`.
 * `2017-03-30:` Added rule that permissions on resources in events must correspond to permissions on API resources
 * `2017-03-30:` Added rule that APIs should be modelled around business processes
 * `2017-02-28:` Extended information about how to reference sub-resources and the usage of composite identifiers in the [Resources](../resources/Resources.md#-bookmust--identify-resources-and-sub-resources-via-path-segments) part.

--- a/data-formats/DataFormats.md
+++ b/data-formats/DataFormats.md
@@ -7,7 +7,7 @@ JSON-encode the body payload. The JSON payload must follow [RFC-7159](https://to
 This also applies for collection resources where one naturally would assume an array. See the
 [pagination](../pagination/Pagination.md#could-use-pagination-links-where-applicable) section for an example.
 
-## {{ book.could }} Use other Media Types than JSON
+## {{ book.may }} Use other Media Types than JSON
 
 If for given use case JSON does not make sense, for instance when providing attachments in form of PDFs, you should
 use another, more sufficient media type. But only do this if you can not transfer the information in JSON.
@@ -20,7 +20,7 @@ Read more about date and time format in [Json Guideline](../json-guidelines/Json
 ###HTTP headers
 Http headers including the proprietary headers. Use the [HTTP date format defined in RFC 7231](http://tools.ietf.org/html/rfc7231#section-7.1.1.1).
 
-## {{ book.could }} Use Standards for Country, Language and Currency Codes
+## {{ book.may }} Use Standards for Country, Language and Currency Codes
 
 Use the following standard formats for country, language and currency codes:
 

--- a/general-guidelines/GeneralGuidelines.md
+++ b/general-guidelines/GeneralGuidelines.md
@@ -1,6 +1,6 @@
 # General Guidelines
 
-The titles are marked with the corresponding labels: {{ book.must }}, {{ book.should }}, {{ book.could }}.
+The titles are marked with the corresponding labels: {{ book.must }}, {{ book.should }}, {{ book.may }}.
 
 ## {{ book.must }} Follow API First Principle
 

--- a/headers/CommonHeaders.md
+++ b/headers/CommonHeaders.md
@@ -15,7 +15,7 @@ they can be used in both, HTTP requests and responses. Commonly used content hea
  - [`Content-Range`](https://tools.ietf.org/html/rfc7233#section-4.2) is used in responses to range requests to indicate which part of the requested resource representation is delivered with the body.
  - [`Content-Type`](https://tools.ietf.org/html/rfc7231#section-3.1.1.5) indicates the media type of the body content.
 
-## {{ book.could }} Use Content-Location Header
+## {{ book.may }} Use Content-Location Header
 
 The Content-Location header is *optional* and can be used in successful write operations (PUT, POST or PATCH) or read operations (GET, HEAD) to guide caching and signal a receiver the actual location of the resource transmitted in the response body. This allows clients to identify the resource and to update their local copy when receiving a response with this header.
 
@@ -41,7 +41,7 @@ As the correct usage of Content-Location with respect to semantics and caching i
 
 More details in RFC 7231 [7.1.2 Location](https://tools.ietf.org/html/rfc7231#section-7.1.2), [3.1.4.2 Content-Location](https://tools.ietf.org/html/rfc7231#section-3.1.4.2)
 
-## {{ book.could }} Use the Prefer header to indicate processing preferences
+## {{ book.may }} Use the Prefer header to indicate processing preferences
 
 The  `Prefer` header defined in [RFC7240](https://tools.ietf.org/html/rfc7240) allows clients to request processing behaviors from servers. [RFC7240](https://tools.ietf.org/html/rfc7240) pre-defines a number of preferences and is extensible, to allow others to be defined. Support for the Prefer header is entirely optional and at the discretion of API designers, but as an existing Internet Standard, is recommended over defining proprietary "X-" headers for processing directives. 
 
@@ -64,7 +64,7 @@ The `Prefer` header can defined like this in an API definition:
 
 Supporting APIs may return the `Preference-Applied` header also defined in [RFC7240](https://tools.ietf.org/html/rfc7240) to indicate whether the preference was applied.
 
-## {{ book.could }} Consider using ETag together with If-(None-)Match header
+## {{ book.may }} Consider using ETag together with If-(None-)Match header
 
 When creating or updating resources it may be necessary to expose conflicts and to prevent the lost update
 problem. This can be best accomplished by using the [`ETag`](https://tools.ietf.org/html/rfc7232#section-2.3)

--- a/hyper-media/Hypermedia.md
+++ b/hyper-media/Hypermedia.md
@@ -12,7 +12,7 @@ You can see this expressed by many rules throughout these guidelines, e.g.:
 
 Although this is not HATEOAS, it should not prevent you from designing proper link relationships in your APIs as stated in rules below.
 
-## {{ book.could }} Use REST Maturity Level 3 - HATEOAS
+## {{ book.may }} Use REST Maturity Level 3 - HATEOAS
 
 We do not generally recommend to implement [REST Maturity Level 3](http://martinfowler.com/articles/richardsonMaturityModel.html#level3). HATEOAS comes with additional API complexity without real value in our SOA context where client and server interact via REST APIs and provide complex business functions as part of our e-commerce SaaS platform.
 
@@ -89,7 +89,7 @@ We don't allow the use of the [`Link` Header defined by RFC 5988](http://tools.i
 in conjunction with JSON media types, and favor [HAL](#must-use-hal) instead. The primary reason is to have a consistent
 place for links as well as the better support for links in JSON payloads compared to the uncommon link header syntax.
 
-## {{ book.could }} Use Custom Link Relations
+## {{ book.may }} Use Custom Link Relations
 
 You should consider using a custom link relation if and only if standard [link relations](http://www.iana.org/assignments/link-relations/link-relations.xml)
 are not sufficient to express a relation.

--- a/json-guidelines/JsonGuidelines.md
+++ b/json-guidelines/JsonGuidelines.md
@@ -50,11 +50,11 @@ When it comes to storage, all dates should be consistently stored in UTC without
 
 Sometimes it can seem data is naturally represented using numerical timestamps, but this can introduce interpretation issues with precision - for example whether to represent a timestamp as 1460062925, 1460062925000 or 1460062925.000. Date strings, though more verbose and requiring more effort to parse, avoid this ambiguity.
 
-### {{ book.could }} Time durations and intervals could conform to ISO 8601
+### {{ book.may }} Time durations and intervals could conform to ISO 8601
 
 Schema based JSON properties that are by design durations and intervals could be strings formatted as recommended by ISO 8601 ([Appendix A of RFC 3399 contains a grammar](https://tools.ietf.org/html/rfc3339#appendix-A) for durations).
 
-### {{ book.could }} Standards could be used for Language, Country and Currency
+### {{ book.may }} Standards could be used for Language, Country and Currency
 
 - [ISO 3166-1-alpha2 country
 ](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)

--- a/naming/Naming.md
+++ b/naming/Naming.md
@@ -31,7 +31,7 @@ Examples:
 See also: [HTTP Headers are case-insensitive
 (RFC 7230)](http://tools.ietf.org/html/rfc7230#page-22).
 
-## {{ book.could }} Use Standardized Headers
+## {{ book.may }} Use Standardized Headers
 
 Use [this list](http://en.wikipedia.org/wiki/List_of_HTTP_header_fields) and mention its support in
 your OpenAPI definition.
@@ -40,7 +40,7 @@ your OpenAPI definition.
 
 Usually, a collection of resource instances is provided (at least API should be ready here). The special case of a resource singleton is a collection with cardinality 1.
 
-## {{ book.could }} Use /api as first Path Segment
+## {{ book.may }} Use /api as first Path Segment
 
 In most cases, all resources provided by a service are part of the public API, and therefore should
 be made available under the root “/” base path. If  the service should also support non-public,
@@ -52,7 +52,7 @@ clearly separate public and non-public API resources.
 The trailing slash must not have specific semantics. Resource paths must deliver the same results
 whether they have the trailing slash or not.
 
-## {{ book.could }} Use Conventional Query Strings
+## {{ book.may }} Use Conventional Query Strings
 
 If you provide query support for sorting, pagination, filtering functions or other actions, use the
 following standardized naming conventions:

--- a/pagination/Pagination.md
+++ b/pagination/Pagination.md
@@ -56,7 +56,7 @@ Further reading:
 * [Paging in PostgreSQL](https://www.citusdata.com/blog/1872-joe-nelson/409-five-ways-paginate-postgres-basic-exotic)
 
 
-## {{ book.could }} Use Pagination Links Where Applicable
+## {{ book.may }} Use Pagination Links Where Applicable
 
 * Set links to provide information to the client about subsequent paging options.
 

--- a/resources/Resources.md
+++ b/resources/Resources.md
@@ -90,7 +90,7 @@ This deficit is addressed by [ULID](https://github.com/alizain/ulid) (Universall
 You may favour ULID instead of UUID, for instance, for pagination use cases ordered along creation time. 
 
 
-## {{ book.could }} Consider Using (Non-) Nested URLs
+## {{ book.may }} Consider Using (Non-) Nested URLs
 
 If a sub-resource is only accessible via its parent resource and may not exists without parent resource, consider using a nested URL structure, for instance:
 


### PR DESCRIPTION
This adds a section describing the use of RFC2119 to describe the
requirements levels for each guideline. The naming changes to the
guideline headings are:

 - book.must: stays the same
 - book.should: stays the same
 - book.could: becomes book.may

For #226.

Example of the new rendering output:

<img width="819" alt="screen shot 2017-05-10 at 10 11 08" src="https://cloud.githubusercontent.com/assets/5454/25891475/1b24136c-3569-11e7-97c6-0ff464609efb.png">

Because of https://github.com/zalando/restful-api-guidelines/issues/231 that was generated using a patched build process. It's probably worth someone else verifying locally.

As a data point for the curious, the guideline levels are distributed as a follows

- must: 62
- should: 33
- could: 14
