### PR TITLE
Introduce simplified hypertext controls for pagination and self-reference

### DIFF
--- a/hyper-media/Hypermedia.md
+++ b/hyper-media/Hypermedia.md
@@ -17,7 +17,7 @@ Although this is not HATEOAS, it should not prevent you from designing proper li
 We do not generally recommend to implement [REST Maturity Level 3](http://martinfowler.com/articles/richardsonMaturityModel.html#level3). HATEOAS comes with additional API complexity without real value in our SOA context where client and server interact via REST APIs and provide complex business functions as part of our e-commerce SaaS platform.
 
 Our major concerns regarding the promised advantages of HATEOAS (see also [RESTistential Crisis over Hypermedia APIs](https://www.infoq.com/news/2014/03/rest-at-odds-with-web-apis for detailed discussion), [Why I Hate HATEOAS](https://jeffknupp.com/blog/2014/06/03/why-i-hate-hateoas/) and others):
-- We follow the [API First principle](../general-guidelines/GeneralGuidelines.md#Must-Follow-API-First-Principle) 
+- We follow the [API First principle](../general-guidelines/GeneralGuidelines.md#must-follow-api-first-principle) 
 with APIs explicitly defined outside the code with standard specification language. HATEOAS does not really add value for SOA client engineers in terms of API self-descriptiveness: a client engineer finds necessary links and usage description (depending on resource state) in the API reference definition anyway.
 - Generic HATEOAS clients which need no prior knowledge about APIs and explore API capabilities based on hypermedia information provided, is a theoretical concept that we haven't seen working in practise and does not fit to our SOA set-up. The OpenAPI description format (and tooling based on OpenAPI) doesn't provide sufficient support for HATEOAS either.
 - In practice relevant HATEOAS approximations (e.g. following specifications like HAL or JSON API) support API navigation by abstracting from URL endpoint and HTTP method aspects via link types. So, Hypermedia does not prevent clients from required manual changes when domain model changes over time.
@@ -26,7 +26,7 @@ with APIs explicitly defined outside the code with standard specification langua
 
 However, we do not forbid HATEOAS; you could use it, if you checked its limitations and still see clear value for your usage scenario that justifies its additional complexity. If you use HATEOAS please share experience and present your findings in the [API Guild \[internal link\]](https://techwiki.zalando.net/display/GUL/API+Guild).
 
-## {{ book.must }} Use common hypertext controls
+## {{ book.must }} Use Common Hypertext Controls
 
 When embedding links to other resources into representations you must use the common hypertext control object. It contains at least one attribute:
 
@@ -77,27 +77,14 @@ allow [HAL](http://stateless.co/hal_specification.html), we actually don't recom
 usage of HAL anymore as the structural separation of meta-data and data creates more harm than value to the 
 understandability and usability of an API.
 
+## {{ book.should }} Pagination and Self-References
+
+Hypertext controls for pagination inside collections and self-references should use a simple URI value in combination with their corresponding [link relations](http://www.iana.org/assignments/link-relations/link-relations.xml) (`next`, `prev`, `first`, `last`, `self`) instead of the extensible common hypertext control 
+
+See [Pagination](../pagination/Pagination.html) for information how to best represent paginateable collections.
+
 ## {{ book.must }} Do Not Use Link Headers with JSON entities
 
 We don't allow the use of the [`Link` Header defined by RFC 5988](http://tools.ietf.org/html/rfc5988#section-5)
-in conjunction with JSON media types, and favor [HAL](#must-use-hal) instead. The primary reason is to have a consistent
-place for links as well as the better support for links in JSON payloads compared to the uncommon link header syntax.
+in conjunction with JSON media types. We prefer links directly embedded in JSON payloads to the uncommon link header syntax.
 
-## {{ book.may }} Use Custom Link Relations
-
-You should consider using a custom link relation if and only if standard [link relations](http://www.iana.org/assignments/link-relations/link-relations.xml)
-are not sufficient to express a relation.
-Related or even embedded (sub-) resources should be linked via “meta link attributes” within the response payload; use
-the following [HAL](http://stateless.co/hal_specification.html) compliant syntax:
-
-    {
-      ...
-      “_links”: {
-        “my-relation”: {
-          “href”: “https://service.team.zalan.do/my-entities/123”
-        }
-      }
-    }
-
-In earlier versions of this rule we proposed URIs but dropped that in favor of readability. Since link relations are
-properties in the `_links` object you should define and describe them individually in the API specification.

--- a/hyper-media/Hypermedia.md
+++ b/hyper-media/Hypermedia.md
@@ -77,13 +77,13 @@ allow [HAL](http://stateless.co/hal_specification.html), we actually don't recom
 usage of HAL anymore as the structural separation of meta-data and data creates more harm than value to the 
 understandability and usability of an API.
 
-## {{ book.should }} Pagination and Self-References
+## {{ book.should }} Use Simple Hypertext Controls for Pagination and Self-References
 
 Hypertext controls for pagination inside collections and self-references should use a simple URI value in combination with their corresponding [link relations](http://www.iana.org/assignments/link-relations/link-relations.xml) (`next`, `prev`, `first`, `last`, `self`) instead of the extensible common hypertext control 
 
 See [Pagination](../pagination/Pagination.html) for information how to best represent paginateable collections.
 
-## {{ book.must }} Do Not Use Link Headers with JSON entities
+## {{ book.must }} Not Use Link Headers with JSON entities
 
 We don't allow the use of the [`Link` Header defined by RFC 5988](http://tools.ietf.org/html/rfc5988#section-5)
 in conjunction with JSON media types. We prefer links directly embedded in JSON payloads to the uncommon link header syntax.

--- a/pagination/Pagination.md
+++ b/pagination/Pagination.md
@@ -64,56 +64,25 @@ Those collections should then have an `items` attribute holding the items of the
 
 You should avoid providing a total count in your API unless there's a clear need to do so. Very often, there are systems and performance implications to supporting full counts, especially as datasets grow and requests become complex queries or filters that drive full scans (e.g., your database might need to look at all candidate items to count them). While this is an implementation detail relative to the API, it's important to consider your ability to support serving counts over the life of a service.
 
-If the collection consists of links to other resources, the collection object name should use [IANA registered link relations](http://www.iana.org/assignments/link-relations/link-relations.xml) as names whenever appropriate, but use plural form.
+If the collection consists of links to other resources, the collection name should use [IANA registered link relations](http://www.iana.org/assignments/link-relations/link-relations.xml) as names whenever appropriate, but use plural form.
 
-E.g. a service for articles could represent an `Article` that embeds a collection `authors` with hyperlinks to the article's authors like that:
-
-```json
-{
-  "self": "https://...",
-  "id": "446f9876-e89b-12d3-a456-426655440000",
-  "title": "Manifesto for Agile Software Development ",
-  "authors": {
-    "index": 0,
-    "page_size": 5,
-    "items": [
-      {  
-        "href": "https://...",
-        "id": "123e4567-e89b-12d3-a456-426655440000",
-        "name": "Kent Beck"
-      },
-      {  
-        "href": "https://...",
-        "id": "987e2343-e89b-12d3-a456-426655440000",
-        "name": "Mike Beedle"
-      },
-      ...
-    ],
-    "first": "https://...",
-    "next": "https://...",
-    "prev": "https://...",
-    "last": "https://..."
-  }
-}
-
-```
-Following any of the pagination links would then return another page of authors
-
+E.g. a service for articles could represent the collection of hyperlinks to an article's `authors` like that:
 
 ```json
 {
-  "index": 5,
+  "self": "https://.../articles/xyz/authors/",
+  "index": 0,
   "page_size": 5,
   "items": [
     {  
       "href": "https://...",
-      "id": "353e4567-e89b-12d3-a456-426655440000",
-      "name": "Martin Fowler"
+      "id": "123e4567-e89b-12d3-a456-426655440000",
+      "name": "Kent Beck"
     },
     {  
       "href": "https://...",
-      "id": "687e2343-e89b-12d3-a456-426655440000",
-      "name": "James Grenning"
+      "id": "987e2343-e89b-12d3-a456-426655440000",
+      "name": "Mike Beedle"
     },
     ...
   ],
@@ -124,15 +93,3 @@ Following any of the pagination links would then return another page of authors
 }
 
 ```
-
-Previous editions of the guidelines required the use HAL compliant hypertext controls. This requirement has been relaxed to enable a more [concise representation and placement of links](../hyper-media/Hypermedia.html#must-use-common-hypertext-controls).
-
-Previous editions of the guidelines also documented the `X-Total-Count` header to send back the total count of entities in conjunction with the `Link` header, which has since been deprecated. Instead when returning an object structure, the count can be added as a JSON property, and this is the preferred way to return count (or other result level) information. 
-
-The `X-Total-Count` is applicable in these cases:
-
-* The API design is still using the `Link` header.
-* The API is returning a non-JSON response media type, and isn't able to carry the information.
-* The JSON response is an array and not an object.
-
-

--- a/pagination/Pagination.md
+++ b/pagination/Pagination.md
@@ -58,41 +58,75 @@ Further reading:
 
 ## {{ book.may }} Use Pagination Links Where Applicable
 
-* Set links to provide information to the client about subsequent paging options.
+* API implementing [HATEOS](../hyper-media/Hypermedia.html#may-use-rest-maturity-level-3--hateoas) may use [simplified hypertext controls](../hyper-media/Hypermedia.html#should-pagination-and-self-references) for pagination within collections.
 
-For example:
+Those collections should then have an `items` attribute holding the items of the current page. The collection may contain additional metadata about the collection or the current page (e.g. `index`, `page_size`) when necessary.
 
-```http
-GET http://catalog-service.zalando.net/products?offset=10&limit=5 HTTP/1.1
-Accept: application/json
+You should avoid providing a total count in your API unless there's a clear need to do so. Very often, there are systems and performance implications to supporting full counts, especially as datasets grow and requests become complex queries or filters that drive full scans (e.g., your database might need to look at all candidate items to count them). While this is an implementation detail relative to the API, it's important to consider your ability to support serving counts over the life of a service.
 
-HTTP/1.1 200 OK
-Content-Type: application/json
+If the collection consists of links to other resources, the collection object name should use [IANA registered link relations](http://www.iana.org/assignments/link-relations/link-relations.xml) as names whenever appropriate, but use plural form.
 
+E.g. a service for articles could represent an `Article` that embeds a collection `authors` with hyperlinks to the article's authors like that:
+
+```json
 {
-  "_links": {
-    "next": {
-      "href": "http://catalog-service.zalando.net/products?offset=15&limit=5"
-    },
-    "prev": {
-      "href": "http://catalog-service.zalando.net/products?offset=5&limit=5"
-    }
-  },
-  "total_count": 42,
-  "products": [
-    {"id": "7e4ab218-1772-11e6-892c-836df3feeaee"},
-    {"id": "9469725a-1772-11e6-83c2-ab22ac368913"},
-    {"id": "a3625d80-1772-11e6-9213-d3a20f9e6bf4"},
-    {"id": "a802f070-1772-11e6-a772-c3020d55eb5f"},
-    {"id": "adb407ac-1772-11e6-b255-078fb28ff55b"}
-  ]
+  "self": "https://...",
+  "id": "446f9876-e89b-12d3-a456-426655440000",
+  "title": "Manifesto for Agile Software Development ",
+  "authors": {
+    "index": 0,
+    "page_size": 5
+    "items": [
+      {  
+        "href": "https://...",
+        "id": "123e4567-e89b-12d3-a456-426655440000",
+        "name": "Kent Beck"
+      },
+      {  
+        "href": "https://...",
+        "id": "987e2343-e89b-12d3-a456-426655440000",
+        "name": "Mike Beedle"
+      },
+      ...
+    ],
+    "first": "https://...",
+    "next": "https://...",
+    "prev": "https://...",
+    "last": "https://..."
+  }
 }
+
+```
+Following any of the pagination links would then just return another page of authors
+
+
+```json
+{
+  "items": [
+    "index": 5,
+    "page_size": 5    {  
+      "href": "https://...",
+      "id": "353e4567-e89b-12d3-a456-426655440000",
+      "name": "Martin Fowler"
+    },
+    {  
+      "href": "https://...",
+      "id": "687e2343-e89b-12d3-a456-426655440000",
+      "name": "James Grenning"
+    },
+    ...
+  ],
+  "first": "https://...",
+  "next": "https://...",
+  "prev": "https://...",
+  "last": "https://..."
+}
+
 ```
 
-[Possible relations](http://www.iana.org/assignments/link-relations/link-relations.xml):
-`next`, `prev`, `last`, `first`.
+Previous editions of the guidlines required the use HAL compliant hypertext controls. This requirement has been relaxed to enable more concise representation of links.
 
-Previous editions of the guidelines documented the `X-Total-Count` header to send back the total count of entities in conjunction with the `Link` header, which has since been deprecated. Instead when returning an object structure, the count can be added as a JSON property, and this is the preferred way to return count (or other result level) information. 
+Previous editions of the guidelines also documented the `X-Total-Count` header to send back the total count of entities in conjunction with the `Link` header, which has since been deprecated. Instead when returning an object structure, the count can be added as a JSON property, and this is the preferred way to return count (or other result level) information. 
 
 The `X-Total-Count` is applicable in these cases:
 
@@ -100,4 +134,4 @@ The `X-Total-Count` is applicable in these cases:
 * The API is returning a non-JSON response media type, and isn't able to carry the information.
 * The JSON response is an array and not an object.
 
-You should avoid providing a total count in your API unless there's a clear need to do so. Very often, there are systems and performance implications to supporting full counts, especially as datasets grow and requests become complex queries or filters that drive full scans (e.g., your database might need to look at all candidate items to count them). While this is an implementation detail relative to the API, it's important to consider your ability to support serving counts over the life of a service.
+

--- a/pagination/Pagination.md
+++ b/pagination/Pagination.md
@@ -75,7 +75,7 @@ E.g. a service for articles could represent an `Article` that embeds a collectio
   "title": "Manifesto for Agile Software Development ",
   "authors": {
     "index": 0,
-    "page_size": 5
+    "page_size": 5,
     "items": [
       {  
         "href": "https://...",
@@ -97,14 +97,15 @@ E.g. a service for articles could represent an `Article` that embeds a collectio
 }
 
 ```
-Following any of the pagination links would then just return another page of authors
+Following any of the pagination links would then return another page of authors
 
 
 ```json
 {
+  "index": 5,
+  "page_size": 5,
   "items": [
-    "index": 5,
-    "page_size": 5    {  
+    {  
       "href": "https://...",
       "id": "353e4567-e89b-12d3-a456-426655440000",
       "name": "Martin Fowler"
@@ -124,7 +125,7 @@ Following any of the pagination links would then just return another page of aut
 
 ```
 
-Previous editions of the guidlines required the use HAL compliant hypertext controls. This requirement has been relaxed to enable more concise representation of links.
+Previous editions of the guidelines required the use HAL compliant hypertext controls. This requirement has been relaxed to enable a more [concise representation and placement of links](../hyper-media/Hypermedia.html#must-use-common-hypertext-controls).
 
 Previous editions of the guidelines also documented the `X-Total-Count` header to send back the total count of entities in conjunction with the `Link` header, which has since been deprecated. Instead when returning an object structure, the count can be added as a JSON property, and this is the preferred way to return count (or other result level) information. 
 


### PR DESCRIPTION
- Adding section on simplified hypertext controls for pagination and self-references
- Updating HATEOAS section in Pagination to no longer use HAL
- Removing other references to HAL from Hypermedia.md