### PR TITLE
Add node version hint

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,5 +1,9 @@
 # Build
 
+## Requirements
+
+You have to use node version 5.1.1 until we upgrade to current Gitbook version.
+
 ## Install all dependencies
 
     npm install

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ E-Book Support
 -----
 
 You can easily generate PDF, ePub, Mobi files out of our guidelines. Please refer to this [explanation](https://toolchain.gitbook.com/ebook.html) - you have to install Callibre.
+You have to use node version 5.1.1 to build the guidelines.
 CAUTION: you need to add version 2.6.7 identifier to every build command:
 
   ```bash


### PR DESCRIPTION
Closes #231 

As proposed, this adds hint about node version to use until we upgrade to current Gitbook version.