### PR TITLE
#278: add regular expression for property names (rule 119)

### DIFF
--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -22,7 +22,7 @@ essential to establish a consistent look and feel such that JSON looks
 as if it came from the same hand.
 
 [#119]
-== {MUST} Property names must match `^[a-zA-Z_$][a-zA-Z_$0-9]$`
+== {MUST} Property names must match `^[a-zA-Z_$][a-zA-Z_$0-9]*$`
 
 Property names are restricted to ASCII encoded strings. The first
 character must be a letter, an underscore or a dollar sign, and

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -22,12 +22,13 @@ essential to establish a consistent look and feel such that JSON looks
 as if it came from the same hand.
 
 [#119]
-== {MUST} Property names must match `^[a-zA-Z_$][a-zA-Z_$0-9]*$`
+== {MUST} Property names must match `^[a-z_][a-z_0-9]*$`
 
-Property names are restricted to ASCII encoded strings. The first
-character must be a letter, an underscore or a dollar sign, and
-subsequent characters can be a letter, an underscore, a dollar sign, or
-a number.
+Property names are restricted to ASCII strings. The first
+character must be a letter, or an underscore, and subsequent
+characters can be a letter, an underscore, or a number.
+
+(It is recommended to use `_` at the start of property names only for keywords like `_links`.)
 
 [#120]
 == {SHOULD} Array names should be pluralized

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -22,7 +22,7 @@ essential to establish a consistent look and feel such that JSON looks
 as if it came from the same hand.
 
 [#119]
-== {MUST} Property names must be an ASCII subset
+== {MUST} Property names must match `^[a-zA-Z_$][a-zA-Z_$0-9]$`
 
 Property names are restricted to ASCII encoded strings. The first
 character must be a letter, an underscore or a dollar sign, and


### PR DESCRIPTION
This makes it clearer already in the table of contents what is actually wanted here, by condensing the ASCII subset explained in the rule into a regular expression.

This fixes an issue which came up in the discussion for #278.

Do we actually want the `$` in property names? Should we say something about when to use it, or what its special meaning is?