### PR TITLE
fix links to PDF + EPUB in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,8 +3,8 @@
 https://travis-ci.org/zalando/restful-api-guidelines[image:https://travis-ci.org/zalando/restful-api-guidelines.svg?branch=master[Build Status]]
 Latest published version:
 http://zalando.github.io/restful-api-guidelines/[*HTML*],
-http://zalando.github.io/restful-api-guidelines/zalando-restful-guidelines.pdf[*PDF*],
-http://zalando.github.io/restful-api-guidelines/zalando-restful-guidelines.epub[*EPUB3*]
+http://zalando.github.io/restful-api-guidelines/zalando-guidelines.pdf[*PDF*],
+http://zalando.github.io/restful-api-guidelines/zalando-guidelines.epub[*EPUB3*]
 
 == Purpose
 


### PR DESCRIPTION
The name was changed during #282, but was then forgot to update in the README.