### PR TITLE
Added meta information requirements

### DIFF
--- a/chapters/general-guidelines.adoc
+++ b/chapters/general-guidelines.adoc
@@ -65,50 +65,53 @@ quality (including API Guideline compliance), already confirmed via team
 internal reviews.
 
 [#101]
-== {MUST} Provide API Reference Definition using OpenAPI
+== {MUST} Provide API Specification using OpenAPI
 
 We use the http://swagger.io/specification/[OpenAPI specification] (aka
-Swagger spec) as standard for our REST API definitions. You *have to
-provide the API definition in YAML format* (instead of JSON) for the
-OpenAPI API definition files due to its improved readability.
+Swagger specification) as standard to define API specifications files.
+API designers have to provide the API specification files using *YAML*
+to improve readability. API specifications must contain the following
+meta information to allow for API management:
 
-Please stick to version 2.0 of the specification for now, until we
-succeed to update all our tooling to support the upcoming version 3.0.
+- `#/info/title` as unique identifying name of the API
+- `#/info/version` to distinguish API specifications versions following
+  <<116, semantic rules>>
+- `#/info/description` containing a proper description of the API
+- `#/info/contact/{name,url,email}` containing the responsible team
 
-We also call the OpenAPI API definition the "API Reference definition"
-(or "API definition"); as a reference manual it provides all information
-needed by an experienced API client developer to use this API.
+Please stick to OpenAPI 2.0 for now, until we succeed to update all our
+tooling to support the upcoming OpenAPI 3.0.
 
-The OpenAPI API specification file should be subject of version control
-together with source code management. Services also have to support an
-<<192,endpoint to access the API Reference definition>> for their external API(s).
+The API specification files should be subject to version control using
+a source code management system - best together with the implementing
+sources. Services have to support an <<192,endpoint to access the API
+specification>> for their external API(s).
 
-Furthermore you should make use of
-https://github.com/zalando-incubator/zally[Zally], our own API linter
-which supports you in designing a guideline compliant API. You find more
-information in the Github repository itself and in
-https://pages.github.bus.zalan.do/ApiGuild/ApiReviewProcedure/[API
-review procedures [internal link]].
+The https://github.com/zalando-incubator/zally[Zalando API Linter Zally]
+should be used to design APIs compliant with this API guideline. Please
+have also a look to the 
+https://pages.github.bus.zalan.do/ApiGuild/ApiReviewProcedure/[API review
+procedures [internal link]].
+
 
 [#102]
-== {SHOULD} Provide User Manual Documentation
+== {SHOULD} Provide API User Manual
 
-In addition to the API as OpenAPI Reference Definition, it’s good
-practice to provide an API User Manual documentation to improve client
-developer experience, especially of engineers that are less experienced
-in using this API. A helpful API User Manual typically describes the
-following API aspects:
+In addition to the API Specification, it is good practice to provide an
+API user manual to improve client developer experience, especially of
+engineers that are less experienced in using this API. A helpful API user
+manual typically describes the following API aspects:
 
-* API’s scope, purpose and use cases
+* API scope, purpose, and use cases
 * concrete examples of API usage
-* edge cases, error situation details and repair hints
+* edge cases, error situation details, and repair hints
 * architecture context and major dependencies - including figures and
 sequence flows
 
-The User Manual must be posted online, e.g. via GitHub Enterprise pages,
-on specific team web servers, or as a Google doc. And don't forget to
-include a link to this user manual into your OpenAPI definition using
-the “externalDocs” property.
+The user manual must be published online, e.g. via GHE pages, on specific
+team web servers, or as a Google doc. Please do not forget to include a
+link to the API user manual into the API specification using the
+`#/externalDocs/url` property.
 
 [#103]
 == {MUST} Write APIs in U.S. English


### PR DESCRIPTION
For API management we have additional meta information requirements, that are also in general helpful for API users. Therfore, I suggest to put them in the general OpenAPI specification section.