### PR TITLE
New guideline for Maps – #278

### DIFF
--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -27,6 +27,57 @@ Others, like Google and Amazon, use both - but not only camelCase. It’s
 essential to establish a consistent look and feel such that JSON looks
 as if it came from the same hand.
 
+[#216]
+==  Define maps using `additionalProperties`, without restriction on key format.
+
+A "map" here is a mapping from string keys to some other type.
+In JSON this is represented as an object, the key-value pairs being represented
+by property names and property values.
+In OpenAPI schema (as well as in JSON schema) they should be represented using
+additionalProperties with a schema for the value type. Such an object should normally
+have no other defined properties.
+
+The map keys don't count as property names in the sense of #118[rule #118], and can
+follow whatever format is natural for their domain. Please document this in the description
+of the map object's schema.
+
+Here is an example for such a map definition (the `translations` property):
+
+```yaml
+definitions:
+  Message:
+    description:
+      A message together with translations in several languages.
+    type: object
+    properties:
+      message_key:
+        type: string
+        description: The message key.
+      translations:
+        description:
+          The translations of this message into several languages.
+          The keys are usual locale identifiers (ISO-639- language codes,
+          together with an optional ISO-3166 country-code, separated by `_`).
+        type: object
+        additionalProperties:
+          type: string
+          description:
+            the translation of this message into the language identified by the key.
+```
+
+An actual JSON object described by this might then look like this:
+```json
+{ "message_key": "hello_world",
+  "translations": {
+    "de": "Hallo Welt!",
+    "en": "Hello World!",
+    "eo": "Saluton mondo!",
+    "cz": "Ahoj Světe!",
+    "el": "Γεια σου κόσμε!"
+  }
+}
+```
+
 [#120]
 == {SHOULD} Array names should be pluralized
 

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -28,7 +28,7 @@ essential to establish a consistent look and feel such that JSON looks
 as if it came from the same hand.
 
 [#216]
-==  Define maps using `additionalProperties`, without restriction on key format.
+== {SHOULD} Define maps using `additionalProperties`, without restriction on key format.
 
 A "map" here is a mapping from string keys to some other type.
 In JSON this is represented as an object, the key-value pairs being represented
@@ -56,8 +56,7 @@ definitions:
       translations:
         description:
           The translations of this message into several languages.
-          The keys are usual locale identifiers (ISO-639- language codes,
-          together with an optional ISO-3166 country-code, separated by `_`).
+          The keys are https://tools.ietf.org/html/bcp47[BCP-47 language tags].
         type: object
         additionalProperties:
           type: string
@@ -67,13 +66,13 @@ definitions:
 
 An actual JSON object described by this might then look like this:
 ```json
-{ "message_key": "hello_world",
+{ "message_key": "color",
   "translations": {
-    "de": "Hallo Welt!",
-    "en": "Hello World!",
-    "eo": "Saluton mondo!",
-    "cz": "Ahoj Světe!",
-    "el": "Γεια σου κόσμε!"
+    "de": "Farbe",
+    "en-US": "color",
+    "en-GB": "colour",
+    "eo": "koloro",
+    "nl": "kleur"
   }
 }
 ```

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -13,22 +13,19 @@ The first some of the following guidelines are about property names,
 the later ones about values.
 
 [#118]
-== {MUST} Property names must be snake_case (and never camelCase)
-
-No established industry standard exists, but many popular Internet
-companies prefer snake_case: e.g. GitHub, Stack Exchange, Twitter.
-Others, like Google and Amazon, use both - but not only camelCase. It’s
-essential to establish a consistent look and feel such that JSON looks
-as if it came from the same hand.
-
-[#119]
-== {MUST} Property names must match `^[a-z_][a-z_0-9]*$`
+== {MUST} Property names must be ASCII snake_case (and never camelCase): `^[a-z_][a-z_0-9]*$`
 
 Property names are restricted to ASCII strings. The first
 character must be a letter, or an underscore, and subsequent
 characters can be a letter, an underscore, or a number.
 
 (It is recommended to use `_` at the start of property names only for keywords like `_links`.)
+
+Rationale: No established industry standard exists, but many popular Internet
+companies prefer snake_case: e.g. GitHub, Stack Exchange, Twitter.
+Others, like Google and Amazon, use both - but not only camelCase. It’s
+essential to establish a consistent look and feel such that JSON looks
+as if it came from the same hand.
 
 [#120]
 == {SHOULD} Array names should be pluralized

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -9,8 +9,8 @@ media type and custom JSON media types defined for APIs. The guidelines
 clarifies some specific cases to allow Zalando JSON data to have an
 idiomatic form across teams and services.
 
-[#117]
-== {MUST} Use Consistent Property Names
+The first some of the following guidelines are about property names,
+the later ones about values.
 
 [#118]
 == {MUST} Property names must be snake_case (and never camelCase)
@@ -35,9 +35,6 @@ characters can be a letter, an underscore, or a number.
 
 To indicate they contain multiple values prefer to pluralize array
 names. This implies that object names should in turn be singular.
-
-[#121]
-== {MUST} Use Consistent Property Values
 
 [#122]
 == {MUST} Boolean property values must not be null


### PR DESCRIPTION
This fixes #278, by adding a new guideline (216, because 215 is already used by #306), indicating how maps should be represented.

On the way, I also merged rules 118 and 119, and removed the pseudo-rules (which were just headings) 117 and 121.

For reviewing, it might be clearer looking at each commit individually.