### PR TITLE
Default to client credentials flow

### DIFF
--- a/chapters/changelog.adoc
+++ b/chapters/changelog.adoc
@@ -13,6 +13,7 @@ To see a list of all changes, please have a look at the https://github.com/zalan
 [[rule-changes]]
 == Rule Changes
 
+* `2017-11-28:` Changed OAuth flow example from password to client credentials in <<security>>.
 * `2017-11-22:` Updated description of X-Tenant-ID header field
 * `2017-08-22:` Migration to Asciidoc
 * `2017-07-20:` Be more precise on client vs. server obligations for compatible API extensions.

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -15,14 +15,14 @@ specification or take a look at the following example.
 securityDefinitions:
   oauth2:
     type: oauth2
-    flow: password
+    flow: clientCredentials
     tokenUrl: https://token.services.auth.zalando.com/oauth2/access_token
     scopes:
       fulfillment-order-service.read: Access right needed to read from the fulfillment order service.
       fulfillment-order-service.write: Access right needed to write to the fulfillment order service.      
 ----
 
-The example defines OAuth2 with password flow as security standard used
+The example defines OAuth2 with client credentials flow as security standard used
 for authentication when accessing endpoints; additionally, there are two
 API access rights defined via the scopes section for later endpoint
 authorization usage - please see next section.
@@ -30,7 +30,7 @@ authorization usage - please see next section.
 It makes little sense specifying the flow to retrieve OAuth tokens in
 the `securityDefinitions` section, as API endpoints should not care, how
 OAuth tokens were created. Unfortunately the `flow` field is mandatory
-and cannot be ommited. API endpoints should always set `flow: password`
+and cannot be ommited. API endpoints should always set `flow: clientCredentials`
 and ignore this information.
 
 [#105]

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -16,7 +16,7 @@ securityDefinitions:
   oauth2:
     type: oauth2
     flow: application
-    tokenUrl: https://sandbox.identity.zalando.com/oauth2/token
+    tokenUrl: https://identity.zalando.com/oauth2/token
     scopes:
       fulfillment-order-service.read: Access right needed to read from the fulfillment order service.
       fulfillment-order-service.write: Access right needed to write to the fulfillment order service.      

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -15,8 +15,8 @@ specification or take a look at the following example.
 securityDefinitions:
   oauth2:
     type: oauth2
-    flow: clientCredentials
-    tokenUrl: https://token.services.auth.zalando.com/oauth2/access_token
+    flow: application
+    tokenUrl: https://sandbox.identity.zalando.com/oauth2/token
     scopes:
       fulfillment-order-service.read: Access right needed to read from the fulfillment order service.
       fulfillment-order-service.write: Access right needed to write to the fulfillment order service.      
@@ -30,7 +30,7 @@ authorization usage - please see next section.
 It makes little sense specifying the flow to retrieve OAuth tokens in
 the `securityDefinitions` section, as API endpoints should not care, how
 OAuth tokens were created. Unfortunately the `flow` field is mandatory
-and cannot be ommited. API endpoints should always set `flow: clientCredentials`
+and cannot be ommited. API endpoints should always set `flow: application`
 and ignore this information.
 
 [#105]


### PR DESCRIPTION
I did notice the note about the `flow` property: 

> Unfortunately the flow field is mandatory and cannot be omitted. API endpoints should always set flow: password and ignore this information.

However I would prefer not to encourage to use a "[discouraged](https://pages.github.bus.zalan.do/foundation/docs/oauth2-guide/oauth2-grants.html?highlight=flow#resource-owner-password-grant)" flow (even if not intended actually).