### PR TITLE
improve guidance on response (status code) documentation

### DIFF
--- a/chapters/http.adoc
+++ b/chapters/http.adoc
@@ -360,31 +360,41 @@ due to overload) -- client retry may be sensible. |All
 |=======================================================================
 
 [#151]
-== {MUST} Provide Error Documentation
+== {MUST} Specify Success and Error Responses
 
 APIs should define the functional, business view and abstract from
-implementation aspects. Errors become a key element providing context
-and visibility into how to use an API. The error object should be
-extended by an application-specific error identifier if and only if the
-HTTP status code is not specific enough to convey the domain-specific
-error semantic. For this reason, we use a standardized error return
-object definition — see <<176>>.
+implementation aspects. Success and error responses are a vital part to
+define how an API is used correctly.
 
-The OpenAPI specification shall include definitions for error
-descriptions that will be returned; they are part of the interface
-definition and provide important information for service clients to
-handle exceptional situations and support troubleshooting. You should
-also think about a troubleshooting board — it is part of the associated
-online API documentation, provides information and handling guidance on
-application-specific errors and is referenced via links of the API
-definition. This can reduce service support tasks and contribute to
-service client and provider performance.
+Therefore, the OpenAPI specification must contain definitions for **all**
+success and error responses. Both are part of the interface definition and
+provide important information for service clients to handle standard as well
+as exceptional situations. For each response the most specific HTTP status
+code should be selected that conveys the domain-specific success or error
+semantic — see <<150>>.
 
-Service providers should differentiate between technical and functional
-errors. In most cases it's not useful to document technical errors that
-are not in control of the service provider unless the status code convey
-application-specific semantics. The list of status code that can be
-omitted from API specifications includes but is not limited to:
+To transport error information beside the status code, we use a standardized
+error return object specification that must be used — see <<176>>.
+
+**Remark:** In most cases it is not useful to document all technical errors,
+especially if they are not under control of the service provider. Thus unless
+a response code conveys application-specific functional semantics or is used
+in a none standard way that requires additional explanation, multiple error
+response specifications can combined using the following pattern:
+
+[source,yaml]
+----
+  default:
+    description: a specific error occurred - see status code for more information.
+    schema:
+      $ref: 'https://zalando.github.io/problem/schema.yaml#/Problem'
+----
+
+**Note:** It is best practice to explicitly specify all successful status codes.
+This prevents any conflict with the above pattern.
+
+The list of status code that in general can be omitted from API specifications
+includes but is not limited to:
 
 * `401 Unauthorized`
 * `403 Forbidden`
@@ -400,15 +410,18 @@ omitted from API specifications includes but is not limited to:
 * `503 Service Unavailable`
 * `504 Gateway Timeout`
 
-Even though they might not be documented - they may very much occur in
-production, so clients should be prepared for unexpected response codes,
-and in case of doubt handle them like they would handle the
-corresponding x00 code. Adding new response codes (specially error
-responses) should be considered a compatible API evolution.
+**Note:** Even though all status code may be documented explicitly, clients
+must always be prepared for responses with unexpected status codes. In case
+of doubt they should handle them like they would handle the corresponding
+x00 code. Adding new response codes (specially error responses) should be
+considered a compatible API evolution.
 
-Functional errors on the other hand, that convey domain-specific
-semantics, must be documented and are strongly encouraged to be
-expressed with <<176>>.
+API designers should also think about a troubleshooting board as part of the
+associated online API documentation. It provides information and handling
+guidance on application-specific errors and is referenced via links from the
+API specification. This can reduce service support tasks and contribute to
+service client and provider performance.
+
 
 [#152]
 == {MUST} Use 207 for Batch or Bulk Requests

--- a/chapters/http.adoc
+++ b/chapters/http.adoc
@@ -380,7 +380,7 @@ error return object specification that must be used — see <<176>>.
 especially if they are not under control of the service provider. Thus unless
 a response code conveys application-specific functional semantics or is used
 in a none standard way that requires additional explanation, multiple error
-response specifications can combined using the following pattern:
+response specifications can be combined using the following pattern:
 
 [source,yaml]
 ----


### PR DESCRIPTION
The guidance on error documentation is partially contradictory. On one side API designers are required to document all errors, on the other side they are allowed to omit technical errors as well as functional errors that do not differ from the default semantic.

To improve the guidance a default pattern is introduced that that solved this conflict and the documentation is extended to successful status codes.