### PR TITLE
Removes private internal Zalando documents.

### DIFF
--- a/chapters/api-operation.adoc
+++ b/chapters/api-operation.adoc
@@ -12,9 +12,7 @@ to profit from the API management infrastructure.
 An API is published by copying its **OpenAPI specification** into the reserved
 **/zalando-apis** directory of the **deployment artifact** used to deploy the
 provisioning service. The directory must only contain **self-contained YAML**
-**files** that each describe one API (see 
-https://docs.google.com/a/zalando.de/document/d/1WBpRHp1DAtz7Pfjt0QwPuZNR1e70APRqUlCCby3JiOM[internal narrative]
-for more details). We prefer this deployment artifact-based method over the
+**files** that each describe one API. We prefer this deployment artifact-based method over the
 past (now legacy) `.well-known/schema-discovery` service endpoint-based
 publishing process, that we only support for backward compatibility reasons.
 

--- a/chapters/common-data-types.adoc
+++ b/chapters/common-data-types.adoc
@@ -52,9 +52,7 @@ See http://stackoverflow.com/a/3730040/342852[Stack Overflow] for more
 info.
 
 Some JSON parsers (NodeJS’s, for example) convert numbers to floats by
-default. After discussing the
-https://docs.google.com/spreadsheets/d/12wTj-2w39f69XZGwRDrosNc1yWPwQpGgEs_DCt5ODaQ[pros
-and cons (internal link)], we’ve decided on "decimal" as our amount format. It
+default. After discussing the pros and cons we’ve decided on "decimal" as our amount format. It
 is not a standard OpenAPI format, but should help us to avoid parsing numbers
 as float / doubles.
 

--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -117,8 +117,7 @@ groups with clear organisational and legal boundaries:
 *component-internal*::
   The API consumers with this audience are restricted to applications of the
   same *functional component* which typically represents a specific *product* 
-  with clear functional scope and ownership 
-  (see https://docs.google.com/document/d/1ZSfVkdX_Dwpz22Xl-CFXgxe1u1eY_IfTNdFNMmnGi8c/edit#heading=h.wwteqf6ovyh[details (internal link)]).
+  with clear functional scope and ownership.
   All services of a functional component / product are owned by a specific dedicated owner
   and engineering team(s). Typical examples of component-internal APIs are APIs 
   being used by internal helper and worker services or that support service operation.

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -9,9 +9,7 @@ _host_, _permission_, and _event names_ within an the application landscape. It
 helps to preserve uniqueness of names while giving readers meaningful context
 information about the addressed component. Besides, the most important aspect
 is, that it allows to keep APIs stable in the case of technical and
-organizational changes (see narrative
-https://docs.google.com/document/d/1ZSfVkdX_Dwpz22Xl-CFXgxe1u1eY_IfTNdFNMmnGi8c[Functional
-Naming of Service APIs (internal link)] for details).
+organizational changes (Zalando for example maintains an internal naming convention).
 
 To make use of this advantages for APIs with a larger <<219, audience>> we
 strongly recommended to follow the functional naming schema for <<224,


### PR DESCRIPTION
Going ahead with removing private links while https://github.com/zalando/restful-api-guidelines/issues/394 gets resolved.