### PR TITLE
Proof reading

### DIFF
--- a/chapters/common-data-types.adoc
+++ b/chapters/common-data-types.adoc
@@ -137,13 +137,6 @@ below.
 addressee:
   description: a (natural or legal) person that gets addressed
   type: object
-  required:
-    - first_name
-    - last_name
-    - street
-    - city
-    - zip
-    - country_code
   properties:
     salutation:
       description: |

--- a/chapters/common-headers.adoc
+++ b/chapters/common-headers.adoc
@@ -56,7 +56,7 @@ requested URI can be used to indicate that the returned resource is
 subject to content negotiations, and that the value provides a more
 specific identifier of the resource.
 * For writing operations PUT and PATCH, an identical location to the
-requested URI, can be used to explicitly indicate that the returned
+requested URI can be used to explicitly indicate that the returned
 resource is the current representation of the newly created or updated
 resource.
 * For writing operations POST and DELETE, a content location can be used

--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -281,12 +281,14 @@ GeneralEvent:
 ----
 
 Event types based on the General Event Category define their custom
-schema payload at the top-level of the document, with the `metadata`
-field being reserved for standard information (the contents of
-`metadata` are described further down in this section).
+schema payload at the top-level of the document, with the
+link:#event-metadata[`metadata`] field being reserved for standard
+information (the contents of link:#event-metadata[`metadata`] are
+described further down in this section).
 
-In the example fragment below, the reserved `metadata` field is shown
-with fields "a" and "b" being defined as part of the custom schema:
+In the example fragment below, the reserved link:#event-metadata[`metadata`]
+field is shown with fields "a" and "b" being defined as part of the custom
+schema:
 
 Note:
 
@@ -361,6 +363,7 @@ Change Event Category:
 * <<202>>
 * <<204>>
 
+[#event-metadata]
 *Event Metadata.*
 
 The General and Data Change event categories share a common structure
@@ -431,13 +434,13 @@ EventMetadata:
 
 Please note than intermediaries acting between the producer of an event
 and its ultimate consumers, may perform operations like validation of
-events and enrichment of an event's `metadata`. For example brokers such
-as Nakadi, can validate and enrich events with arbitrary additional
-fields that are not specified here and may set default or other values,
-if some of the specified fields are not supplied. How such systems work
-is outside the scope of these guidelines but producers and consumers
-working with such systems should look into their documentation for
-additional information.
+events and enrichment of an event's link:#event-metadata[`metadata`]. For
+example brokers such as Nakadi, can validate and enrich events with
+arbitrary additional fields that are not specified here and may set default
+or other values, if some of the specified fields are not supplied. How
+such systems work is outside the scope of these guidelines but producers
+and consumers working with such systems should look into their documentation
+for additional information.
 
 [#199]
 == {MUST} Ensure that Events define useful business resources
@@ -720,13 +723,13 @@ on the use of `additionalProperties`.
 
 The `eid` (event identifier) value of an event must be unique.
 
-The `eid` property is part of the standard metadata for an event and
-gives the event an identifier. Producing clients must generate this
-value when sending an event and it must be guaranteed to be unique from
-the perspective of the owning application. In particular events within a
-given event type's stream must have unique identifiers. This allows
-consumers to process the `eid` to assert the event is unique and use it
-as an idempotency check.
+The `eid` property is part of the standard link:#event-metadata[metadata]
+for an event and gives the event an identifier. Producing clients must
+generate this value when sending an event and it must be guaranteed to
+be unique from the perspective of the owning application. In particular
+events within a given event type's stream must have unique identifiers.
+This allows consumers to process the `eid` to assert the event is unique
+and use it as an idempotency check.
 
 Note that uniqueness checking of the `eid` might be not enforced by
 systems consuming events and it is the responsibility of the producer to

--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -765,9 +765,8 @@ key to recreate a (partially) ordered sequence of events.
 [#213]
 == {MUST} Follow Naming Convention for Event Type Names
 
-Event type names must, respectively should conform to the functional naming
-depending on the <<219, audience>> as follows (see <<223>> for details and
-`<functional-name>` definition):
+Event type names must (or should, see <<223>> for details and definition)
+conform to the functional naming depending on the <<219, audience>> as follows:
 
 [source,bnf]
 ----

--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -133,8 +133,7 @@ resource instances
 resource addressed by the URL as defined by the change request in the
 payload
 * successful PATCH requests will usually generate 200 or 204 (if
-resources have been updated
-* with or without updated content returned)
+resources have been updated with or without updated content returned)
 
 *Note:* since implementing PATCH correctly is a bit tricky, we strongly
 suggest to choose one and only one of the following patterns per

--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -117,7 +117,7 @@ practice to implement POST in an idempotent way.
 [[patch]]
 === PATCH
 
-PATCH request are only used for partial update of single resources, i.e.
+PATCH requests are only used for partial update of single resources, i.e.
 where only a specific subset of resource fields should be replaced. The
 semantic is best described as »_please change the resource identified by
 the URL according to my change request_«. The semantic of the change
@@ -169,14 +169,14 @@ signal the server stricter demands to expose conflicts and prevent lost updates.
 [#delete]
 === DELETE
 
-DELETE request are used to delete resources. The semantic is best
+DELETE requests are used to delete resources. The semantic is best
 described as »_please delete the resource identified by the URL_«.
 
 * DELETE requests are usually applied to single resources, not on
 collection resources, as this would imply deleting the entire collection
-* successful DELETE request will usually generate 200 (if the deleted
+* successful DELETE requests will usually generate 200 (if the deleted
 resource is returned) or 204 (if no content is returned)
-* failed DELETE request will usually generate 404 (if the resource
+* failed DELETE requests will usually generate 404 (if the resource
 cannot be found) or 410 (if the resource was already deleted before)
 
 [[head]]


### PR DESCRIPTION
fix 397
fix 396

# Findings fixed here
- https://github.com/zalando/restful-api-guidelines/issues/397
- https://github.com/zalando/restful-api-guidelines/issues/396
- adress-fields
  - The example [there](https://opensource.zalando.com/restful-api-guidelines/#address-fields) does not make sense. `addressee` has `required` fields that are not even in its `properties` list and a second `required` block. The first one should be deleted.
- https://opensource.zalando.com/restful-api-guidelines/#179
  - remove the comma in "an identical location to the requested URI, can be used to explicitly indicate that the returned"
- Add anchor to `Event Metadata.` section and link to it from where it is referenced `$ref: '#/definitions/EventMetadata'`.
- https://opensource.zalando.com/restful-api-guidelines/#213
  - change
    - >Event type names must, respectively should conform to the functional naming depending on the audience as follows (see Must/Should: Use Functional Naming Schema for details and definition):
  - to
    - >Event type names must (or should, see Must/Should: Use Functional Naming Schema for details and definition) conform to the functional naming depending on the audience as follows: