### PR TITLE
Use internal link syntax

### DIFF
--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -282,11 +282,11 @@ GeneralEvent:
 
 Event types based on the General Event Category define their custom
 schema payload at the top-level of the document, with the
-link:#event-metadata[`metadata`] field being reserved for standard
-information (the contents of link:#event-metadata[`metadata`] are
+<<event-metadata,metadata>> field being reserved for standard
+information (the contents of <<event-metadata,metadata>> are
 described further down in this section).
 
-In the example fragment below, the reserved link:#event-metadata[`metadata`]
+In the example fragment below, the reserved <<event-metadata,metadata>>
 field is shown with fields "a" and "b" being defined as part of the custom
 schema:
 
@@ -434,7 +434,7 @@ EventMetadata:
 
 Please note than intermediaries acting between the producer of an event
 and its ultimate consumers, may perform operations like validation of
-events and enrichment of an event's link:#event-metadata[`metadata`]. For
+events and enrichment of an event's <<event-metadata,metadata>>. For
 example brokers such as Nakadi, can validate and enrich events with
 arbitrary additional fields that are not specified here and may set default
 or other values, if some of the specified fields are not supplied. How
@@ -723,7 +723,7 @@ on the use of `additionalProperties`.
 
 The `eid` (event identifier) value of an event must be unique.
 
-The `eid` property is part of the standard link:#event-metadata[metadata]
+The `eid` property is part of the standard <<event-metadata,metadata>>
 for an event and gives the event an identifier. Producing clients must
 generate this value when sending an event and it must be guaranteed to
 be unique from the perspective of the owning application. In particular


### PR DESCRIPTION
```
<<event-metadata,metadata>>
```
instead of
```
link:#event-metadata[`metadata`]
```