### PR TITLE
Specify other names used for `component-internal` audience

### DIFF
--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -114,7 +114,8 @@ for discoverability, changeability, quality of design and documentation, as
 well as permission granting. We differentiate the following API audience
 groups with clear organisational and legal boundaries: 
 
-*component-internal* (aka team/product internal)::
+*component-internal*::
+  This is often referred to as *team internal* or *product internal*.
   The API consumers with this audience are restricted to applications of the
   same *functional component* which typically represents a specific *product* 
   with clear functional scope and ownership.

--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -115,7 +115,7 @@ well as permission granting. We differentiate the following API audience
 groups with clear organisational and legal boundaries: 
 
 *component-internal*::
-  This is often referred to as *team internal* or *product internal*.
+  This is often referred to as a _team internal API_ or a _product internal API_.
   The API consumers with this audience are restricted to applications of the
   same *functional component* which typically represents a specific *product* 
   with clear functional scope and ownership.

--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -114,7 +114,7 @@ for discoverability, changeability, quality of design and documentation, as
 well as permission granting. We differentiate the following API audience
 groups with clear organisational and legal boundaries: 
 
-*component-internal*::
+*component-internal* (aka team/product internal)::
   The API consumers with this audience are restricted to applications of the
   same *functional component* which typically represents a specific *product* 
   with clear functional scope and ownership.


### PR DESCRIPTION
As agreed this morning with @tfrauenstein , @tkrop and @maxim-tschumak , we need to indicate in the API Guideline that the `component-internal` audience is also referred to, sometimes, as `product internal` or `team internal`.