### PR TITLE
Added sentence about disallowing maps from being top level objects

### DIFF
--- a/chapters/compatibility.adoc
+++ b/chapters/compatibility.adoc
@@ -143,6 +143,10 @@ JSON objects support compatible extension by additional attributes. This
 allows you to easily extend your response and e.g. add pagination later,
 without breaking backwards compatibility.
 
+Maps, see <<216, rule 216>>, even though technically objects are also
+forbidden as top level data structures, since they don't support compatible,
+future extensions.
+
 [#111]
 == {MUST} Treat Open API Definitions As Open For Extension By Default
 


### PR DESCRIPTION
The possibility to return a map (which is non-extensible by design) as the top-level object was likely overseen before. We don't want this, this sentence makes is clear.