### PR TITLE
 Event types include Audience definition

### DIFF
--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -176,16 +176,16 @@ EventType:
       example: |
         transactions.order.order-cancelled
         customer.personal-data.email-changed
-  audience:
-        type: string
-        x-extensible-enum:
-          - component-internal
-          - business-unit-internal
-          - company-internal
-          - external-partner
-          - external-public
-        description: |
-          Intended target audience of the event type, analogue to <<219,REST API audience definition>>.
+    audience:
+      type: string
+      x-extensible-enum:
+        - component-internal
+        - business-unit-internal
+        - company-internal
+        - external-partner
+        - external-public
+      description: |
+        Intended target audience of the event type, analogue to <<219,REST API audience definition>>.
     owning_application:
       description: |
         Name of the application (eg, as would be used in infrastructure

--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -185,7 +185,8 @@ EventType:
         - external-partner
         - external-public
       description: |
-        Intended target audience of the event type, analogue to <<219,REST API audience definition>>.
+        Intended target audience of the event type, analogue to audience definition for REST APIs 
+        in rule #219 -- see https://opensource.zalando.com/restful-api-guidelines/#219
     owning_application:
       description: |
         Name of the application (eg, as would be used in infrastructure

--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -185,7 +185,7 @@ EventType:
           - external-partner
           - external-public
         description: |
-          Intended target audience of the event type -- see <<219>>
+          Intended target audience of the event type, analogue to <<219,REST API audience definition>>.
     owning_application:
       description: |
         Name of the application (eg, as would be used in infrastructure

--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -103,6 +103,7 @@ follows:
 * A well known event category, such as a general or data change
 category.
 * The name of the event type.
+* The definition of the <<219,event target audience>>. 
 * An owning application, and by implication, an owning team.
 * A schema defining the event payload.
 * The compatibility mode for the type.
@@ -175,6 +176,16 @@ EventType:
       example: |
         transactions.order.order-cancelled
         customer.personal-data.email-changed
+  audience:
+        type: string
+        x-extensible-enum:
+          - component-internal
+          - business-unit-internal
+          - company-internal
+          - external-partner
+          - external-public
+        description: |
+          Intended target audience of the event type -- see <<219>>
     owning_application:
       description: |
         Name of the application (eg, as would be used in infrastructure


### PR DESCRIPTION
Like for REST APIs, Audience should be also defined in Event APIs. Now supported by Nakadi!