### PR TITLE
Emphazise specification via default error handling

### DIFF
--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -58,12 +58,12 @@ Below we list the most commonly used and best understood HTTP status codes,
 consistent with their semantic in the RFCs. APIs should only use these to
 prevent misconceptions that arise from less commonly used HTTP status codes.
 
-As long as your HTTP status code usage is well covered by the semantic defined
-here, you should not describe it to avoid an overload with common sense
-information and the risk of inconsistent definitions. Only if the HTTP status
-code is not in the list below or its usage requires additional information
-aside the well defined semantic, the API specification must provide a clear
-description of the HTTP status code in the response.
+**Important:** As long as your HTTP status code usage is well covered by the
+semantic defined here, you should not describe it to avoid an overload with
+common sense information and the risk of inconsistent definitions. Only if the
+HTTP status code is not in the list below or its usage requires additional
+information aside the well defined semantic, the API specification must provide
+a clear description of the HTTP status code in the response.
 
 [[success-codes]]
 === Success Codes


### PR DESCRIPTION
In API reviews I often can find error specifications that just repeat the standard and provide no value for consumers. So I suggest to more emphasize the paragraph that suggest to remove this error specifications.