### PR TITLE
Add a general guidance on resource identifiers

### DIFF
--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -83,9 +83,7 @@ approach.
 *Note:* In the rare cases where PUT is although used for resource creation,
 the resource IDs are maintained by the client and passed as a URL path segment.
 Putting the same resource twice is required to be idempotent and to result in
-the same single resource instance. If PUT is applied for creating a resource,
-only URIs should be allowed as resource IDs. If URIs are not available POST
-should be preferred.
+the same single resource instance.
 
 
 [[post]]

--- a/chapters/resources.adoc
+++ b/chapters/resources.adoc
@@ -65,6 +65,14 @@ definition. For example, "sales-order-items" is superior to
 "order-items" in that it clearly indicates which business object it
 represents. Along these lines, "items" is too general.
 
+[#228]
+== {MUST} Use URL-friendly Resource Identifiers: [a-zA-Z0-9:._-]*
+
+To simplify encoding of resource IDs in URLs, their representation
+must only consist of ASCII strings of letters, numbers, underscore,
+minus, colon, and period.
+
+
 [#143]
 == {MUST} Identify resources and Sub-Resources via Path Segments
 


### PR DESCRIPTION
Closes #436.

This PR contains a guideline change. It contains a new rule to restrict the characters used for a resource identifier. In general resource identifiers should already be restricted to this set, but this assumption may be false in practice.

I'm although not sure, whether Zally should enforce this rule by checking whether resource-id definitions are always restrained to `[\w:.-]*`.