### PR TITLE
feat: link pagination with query parameters and improve wording (#445)

### DIFF
--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -160,7 +160,6 @@ paginating, you must stick to the following naming conventions:
   `embed` correctly is difficult, so do it with care. See <<158>> below.
 * `offset` — numeric offset of the first element on a page. See <<pagination>>
   section below.
-  paque value, never to be inspected/constructed, addresses a single page
 * `cursor` — an opaque pointer to a page, never to be inspected/constructed by
   clients. It usually (encrypted) encodes the identifier of the first or last
   page element, the pagination direction, and the applied query filters to

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -149,15 +149,19 @@ If you provide query support for searching, sorting, filtering, and
 paginating, you must stick to the following naming conventions:
 
 * `q` — default query parameter (e.g. used by browser tab completion);
-should have an entity specific alias, like sku
-* `sort` — comma-separated list of fields to sort. To indicate sorting
-direction, fields may be prefixed with + (ascending) or - (descending,
-default), e.g. /sales-orders?sort=+id
-* `fields` — to retrieve a subset of fields. See <<157>> below.
-* `embed` — to expand embedded entities (ie.: inside of an article
-entity, expand silhouette code into the silhouette object). Implementing
-"expand" correctly is difficult, so do it with care. See <<158>> below.
-* `cursor` — key-based page start. See <<pagination>> section below.
-* `offset` — numeric offset page start. See <<pagination>> section below.
-* `limit` — to restrict the number of entries. See <<pagination>> section
-below.
+  should have an entity specific alias, like sku
+* `sort` — comma-separated list of fields to define the sort order. To
+  indicate sorting direction, fields may be prefixed with + (ascending) or
+  - (descending, default), e.g. /sales-orders?sort=+id
+* `fields` — to retrieve only a subset of fields of a resource. See <<157>>
+  below.
+* `embed` — to expand or embedded sub-entities (ie.: inside of an article
+  entity, expand silhouette code into the silhouette object). Implementing
+  `embed` correctly is difficult, so do it with care. See <<158>> below.
+* `offset` — numeric offset of the first element on a page. See <<pagination>>
+  section below.
+* `cursor` — encoded pointer to the first or last element on a page, the
+  pagination direction, and the applied query filters. See <<pagination>>
+  section below.
+* `limit` — client suggested limit to restrict the number of entries on
+  a page. See <<pagination>> section below.

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -143,27 +143,23 @@ The trailing slash must not have specific semantics. Resource paths must
 deliver the same results whether they have the trailing slash or not.
 
 [#137]
-== {MAY} Use Conventional Query Strings
+== {MUST} Stick to Conventional Query Parameters
 
-If you provide query support for sorting, pagination, filtering
-functions or other actions, use the following standardized naming
-conventions:
+If you provide query support for searching, sorting, filtering, and
+paginating, you must stick to the following naming conventions:
 
 * `q` — default query parameter (e.g. used by browser tab completion);
 should have an entity specific alias, like sku
-* `limit` — to restrict the number of entries. See Pagination section
-below. Hint: You can use size as an alternate query string.
+* `sort` — comma-separated list of fields to sort. To indicate sorting
+direction, fields may be prefixed with + (ascending) or - (descending,
+default), e.g. /sales-orders?sort=+id
+* `fields` — to retrieve a subset of fields. See <<157>> below.
+* `embed` — to expand embedded entities (ie.: inside of an article
+entity, expand silhouette code into the silhouette object). Implementing
+"expand" correctly is difficult, so do it with care. See <<158>> below.
 * `cursor` — key-based page start. See <<pagination>> section below.
 * `offset` — numeric offset page start. See <<pagination>> section below.
 Hint: In combination with limit, you can use page as an alternative to
 offset.
-* `sort` — comma-separated list of fields to sort. To indicate sorting
-direction, fields may be prefixed with + (ascending) or - (descending,
-default), e.g. /sales-orders?sort=+id
-* `fields` — to retrieve a subset of fields. See
-<<157,_Support Filtering of Resource Fields_>> below.
-* `embed` — to expand embedded entities (ie.: inside of an article
-entity, expand silhouette code into the silhouette object). Implementing
-"expand" correctly is difficult, so do it with care.
-
-
+* `limit` — to restrict the number of entries. See <<pagination>> section
+below.

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -148,11 +148,11 @@ deliver the same results whether they have the trailing slash or not.
 If you provide query support for searching, sorting, filtering, and
 paginating, you must stick to the following naming conventions:
 
-* `q` — default query parameter (e.g. used by browser tab completion);
-  should have an entity specific alias, like sku
-* `sort` — comma-separated list of fields to define the sort order. To
-  indicate sorting direction, fields may be prefixed with + (ascending) or
-  - (descending), e.g. /sales-orders?sort=+id
+* `q` — default query parameter (e.g. used by browser tab completion); should
+  have an entity specific alias, like sku
+* `sort` — comma-separated list of fields to define the sort order. To indicate
+  sorting direction, fields may be prefixed with `+` (ascending) or `-`
+  (descending), e.g. /sales-orders?sort=+id
 * `fields` — to retrieve only a subset of fields of a resource. See <<157>>
   below.
 * `embed` — to expand or embedded sub-entities (ie.: inside of an article
@@ -160,8 +160,10 @@ paginating, you must stick to the following naming conventions:
   `embed` correctly is difficult, so do it with care. See <<158>> below.
 * `offset` — numeric offset of the first element on a page. See <<pagination>>
   section below.
-* `cursor` — encoded pointer to the first or last element on a page, the
-  pagination direction, and the applied query filters. See <<pagination>>
-  section below.
+  paque value, never to be inspected/constructed, addresses a single page
+* `cursor` — an opaque pointer to a page, never to be inspected/constructed by
+  clients. It usually (encrypted) encodes the identifier of the first or last
+  page element, the pagination direction, and the applied query filters to
+  recreate the collection. See <<pagination>> section below.
 * `limit` — client suggested limit to restrict the number of entries on
   a page. See <<pagination>> section below.

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -152,7 +152,7 @@ paginating, you must stick to the following naming conventions:
   should have an entity specific alias, like sku
 * `sort` — comma-separated list of fields to define the sort order. To
   indicate sorting direction, fields may be prefixed with + (ascending) or
-  - (descending, default), e.g. /sales-orders?sort=+id
+  - (descending), e.g. /sales-orders?sort=+id
 * `fields` — to retrieve only a subset of fields of a resource. See <<157>>
   below.
 * `embed` — to expand or embedded sub-entities (ie.: inside of an article

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -159,7 +159,5 @@ entity, expand silhouette code into the silhouette object). Implementing
 "expand" correctly is difficult, so do it with care. See <<158>> below.
 * `cursor` — key-based page start. See <<pagination>> section below.
 * `offset` — numeric offset page start. See <<pagination>> section below.
-Hint: In combination with limit, you can use page as an alternative to
-offset.
 * `limit` — to restrict the number of entries. See <<pagination>> section
 below.

--- a/chapters/pagination.adoc
+++ b/chapters/pagination.adoc
@@ -73,10 +73,9 @@ in PostgreSQL]
 * API implementing <<163,HATEOS>> may use <<165,simplified hypertext controls>>
 for pagination within collections.
 
-Those collections should then have an `items` attribute holding the
-items of the current page. The collection may contain additional
-metadata about the collection or the current page (e.g. `index`,
-`page_size`) when necessary.
+Those collections should then have an `items` attribute holding the items of
+the current page. The collection may contain additional metadata about the
+collection or the current page (e.g. `index`) when necessary.
 
 You should avoid providing a total count in your API unless there's a
 clear need to do so. Very often, there are systems and performance

--- a/chapters/pagination.adoc
+++ b/chapters/pagination.adoc
@@ -4,26 +4,30 @@
 [#159]
 == {MUST} Support Pagination
 
-Access to lists of data items must support pagination for best client
-side batch processing and iteration experience. This holds true for all
-lists that are (potentially) larger than just a few hundred entries.
+Access to lists of data items must support pagination to protect the service
+against overload as well as for best client side iteration and batch processing
+experience. This holds true for all lists that are (potentially) larger than
+just a few hundred entries.
 
-There are two page iteration techniques:
+There are two well known page iteration techniques:
 
 * https://developer.infoconnect.com/paging-results[Offset/Limit-based
 pagination]: numeric offset identifies the first page entry
-* https://dev.twitter.com/overview/api/cursoring[Cursor-based] — aka
-key-based — pagination: a unique key element identifies the first page
-entry (see also
+* https://dev.twitter.com/overview/api/cursoring[Cursor/Limit-based] — aka
+key-based — pagination: a unique key element identifies the first page entry
+(see also
 https://developers.facebook.com/docs/graph-api/using-graph-api/v2.4#paging[Facebook’s
 guide])
 
-The technical conception of pagination should also consider user
-experience related issues. As mentioned in this
+The technical conception of pagination should also consider user experience
+related issues. As mentioned in this
 https://www.smashingmagazine.com/2016/03/pagination-infinite-scrolling-load-more-buttons/[article],
-jumping to a specific page is far less used than navigation via
-next/previous page links. This favours cursor-based over offset-based
+jumping to a specific page is far less used than navigation via `next`/`prev`
+page links (See <<161>>). This favours cursor-based over offset-based
 pagination.
+
+**Note:** To provide a consistent look and feel of pagination patterns,
+you must stick to the common query parameter names defined in <<137>>.
 
 [#160]
 == {SHOULD} Prefer Cursor-Based Pagination, Avoid Offset-Based Pagination


### PR DESCRIPTION
Closes #445.

This change tries to better communicate a consistent look and feel of APIs.

While it replaces a `MAY` by a `MUST`, I think this was the intended semantic for providing conventional query parameters supporting query parameters for searching, sorting, filtering, and paginating. Thus I'm not sure whether this is a guideline change.

I also remove the alternate `size` for `limit`, and `page` for `offset` to enforce a stricter look and feel. If voted for I will reintroduce them again.