### PR TITLE
Fix verbatim formatting

### DIFF
--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -166,7 +166,7 @@ still showing readable patch requests (see also
 http://erosb.github.io/post/json-patch-vs-merge-patch[JSON patch vs. merge]).
 
 *Tip:* To prevent unnoticed concurrent updates when using PATCH, the
-combination of <<182,`ETag`and `If-Match`>> headers should be considered to
+combination of <<182,`ETag` and `If-Match`>> headers should be considered to
 signal the server stricter demands to expose conflicts and prevent lost
 updates.
 


### PR DESCRIPTION
# Problem

The "and" between `ETag` and `If-Match` is formatted as verbatim together with the enclosing words.

![image](https://user-images.githubusercontent.com/3427394/48422385-d1f16380-e75e-11e8-9799-18f1f759f240.png)

# Fix

I included an additional whitespace to make `ETag` and `If-Match` appear as separate verbatim formatted words.

![image](https://user-images.githubusercontent.com/3427394/48422424-e9c8e780-e75e-11e8-85d0-b2ebe122955e.png)