### PR TITLE
feat: applied references for ISO and RFC consistently (#491)

### DIFF
--- a/chapters/common-headers.adoc
+++ b/chapters/common-headers.adoc
@@ -81,7 +81,7 @@ More details in RFC 7231 {RFC-7231}#section-7.1.2[7.1.2 Location],
 [#181]
 == {MAY} Consider to Support `Prefer` Header to Handle Processing Preferences
 
-The {Prefer} header defined in {RFC-7240}[RFC-7240] allows clients to request
+The {Prefer} header defined in {RFC-7240}[RFC 7240] allows clients to request
 processing behaviors from servers. It pre-defines a number of preferences and
 is extensible, to allow others to be defined. Support for the {Prefer} header
 is entirely optional and at the discretion of API designers, but as an existing
@@ -119,7 +119,7 @@ components:
 ----
 
 Supporting APIs may return the {Preference-Applied} header also defined in
-{RFC7240}[RFC-7240] to indicate whether a preference has been applied.
+{RFC7240}[RFC 7240] to indicate whether a preference has been applied.
 
 [#182]
 == {MAY} Consider to Support `ETag` Together With `If-Match`/`If-None-Match` Header

--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -5,11 +5,10 @@
 == {MUST} Use JSON to Encode Structured Data
 
 Use JSON-encoded body payload for transferring structured data. The JSON
-payload must follow https://tools.ietf.org/html/rfc7159[RFC-7159] by
-having (if possible) a serialized object as the top-level structure,
-since it would allow for future extension. This also applies for
-collection resources where one naturally would assume an array. See <<161>> for
-an example.
+payload must follow {RFC-7159}[RFC 7159] by having (if possible) a serialized
+object as the top-level structure, since it would allow for future extension.
+This also applies for collection resources where one naturally would assume an
+array. See <<161>> for an example.
 
 [#168]
 == {MAY} Use non JSON Media Types for Binary Data or Alternative Content Representations
@@ -17,11 +16,10 @@ an example.
 Other media types may be used in following cases:
 
 * Transferring binary data or data whose structure is not relevant. This is
-the case if payload structure is not interpreted and consumed by clients as is.
-Example of such use case is downloading images in formats JPG, PNG, GIF.
-* In addition to JSON version alternative data representations (e.g. in
-formats PDF, DOC, XML) may be made available through content
-negotiation.
+  the case if payload structure is not interpreted and consumed by clients as
+  is. Example of such use case is downloading images in formats JPG, PNG, GIF.
+* In addition to JSON version alternative data representations (e.g. in formats
+  PDF, DOC, XML) may be made available through content negotiation.
 
 [#172]
 == {SHOULD} Prefer standard Media type name `application/json`
@@ -32,11 +30,9 @@ anymore and should be avoided, except where it is necessary for cases of
 <<114,media type versioning>>. Instead, just use the standard media type name
 `application/json` (or `application/problem+json` for <<176>>).
 
-Custom media types beginning with `x` bring no advantage
-compared to the standard media type for JSON, and make automated
-processing more difficult. They are also
-https://tools.ietf.org/html/rfc6838#section-3.4[discouraged by RFC
-6838].
+Custom media types beginning with `x` bring no advantage compared to the
+standard media type for JSON, and make automated processing more difficult.
+They are also {RFC-6838}#section-3.4[discouraged by RFC 6838].
 
 [#169]
 == {MUST} Use Standard Date and Time Formats
@@ -50,8 +46,7 @@ Read more about date and time format in <<126>>.
 === HTTP headers
 
 Http headers including the proprietary headers use the
-http://tools.ietf.org/html/rfc7231#section-7.1.1.1[HTTP date format
-defined in RFC 7231].
+{RFC-7231}#section-7.1.1.1[HTTP date format defined in RFC 7231].
 
 [#170]
 == {MAY} Use Standards for Country, Language and Currency Codes
@@ -59,14 +54,12 @@ defined in RFC 7231].
 Use the following standard formats for country, language and currency
 codes:
 
-* https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2[ISO 3166-1-alpha2
-country codes]
+* {ISO-3166-1-a2}[ISO 3166-1-alpha2 country codes]
 ** (It is "GB", not "UK", even though "UK" has seen some use at Zalando)
-* https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes[ISO 639-1
-language code]
-** https://tools.ietf.org/html/bcp47[BCP-47] (based on ISO 639-1) for
-language variants
-* https://en.wikipedia.org/wiki/ISO_4217[ISO 4217 currency codes]
+* {ISO-639-1}[ISO 639-1 language code]
+** https://tools.ietf.org/html/bcp47[BCP-47] (based on {ISO-639-1}[ISO 639-1])
+   for language variants
+* {ISO-4217}[ISO 4217 currency codes]
 
 [#171]
 == {MUST} Define Format for Type Number and Integer

--- a/chapters/deprecation.adoc
+++ b/chapters/deprecation.adoc
@@ -52,12 +52,11 @@ uncontrolled breaking effects. See also the <<193>>.
 [#189]
 == {SHOULD} Add a Warning Header to Responses
 
-During deprecation phase, the producer should add a `Warning` header
-(see https://tools.ietf.org/html/rfc7234#section-5.5[RFC 7234 - Warning
-header]) field. When adding the `Warning` header, the `warn-code` must
-be `299` and the `warn-text` should be in form of _"The
-path/operation/parameter/... \{name} is deprecated and will be removed
-by \{date}. Please see \{link} for details."_ with a link to a
+During deprecation phase, the producer should add a `Warning` header (see
+{RFC-7234}#section-5.5[RFC 7234 - Warning header]) field. When adding the
+`Warning` header, the `warn-code` must be `299` and the `warn-text` should be
+in form of _"The path/operation/parameter/... \{name} is deprecated and will
+be removed by \{date}. Please see \{link} for details."_ with a link to a
 documentation describing why the API is no longer supported in the
 current form and what clients should do about it. Adding the `Warning`
 header is not sufficient to gain client consent to shut down an API.

--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -139,24 +139,23 @@ resources have been updated with or without updated content returned)
 to choose one and only one of the following patterns per endpoint, unless
 forced by a <<106,backwards compatible change>>. In preference order:
 
-1. use {PUT} with complete objects to update a resource as long as feasible (i.e.
-do not use {PATCH} at all).
-2. use {PATCH} with partial objects to only update parts of a resource, whenever
-possible. (This is basically https://tools.ietf.org/html/rfc7396[JSON Merge
-Patch], a specialized media type `application/merge-patch+json` that is a partial
-resource representation.)
-3. use {PATCH} with http://tools.ietf.org/html/rfc6902[JSON Patch], a specialized
-media type `application/json-patch+json` that includes instructions on how to
-change the resource.
-4. use {POST} (with a proper description of what is happening) instead of {PATCH},
-if the request does not modify the resource in a way defined by the semantics
-of the media type.
+1. use {PUT} with complete objects to update a resource as long as feasible
+  (i.e. do not use {PATCH} at all).
+2. use {PATCH} with partial objects to only update parts of a resource,
+   whenever possible. (This is basically {RFC-7396}[JSON Merge Patch], a
+   specialized media type `application/merge-patch+json` that is a partial
+   resource representation.)
+3. use {PATCH} with {RFC-6902}[JSON Patch], a specialized media type
+   `application/json-patch+json` that includes instructions on how to change
+   the resource.
+4. use {POST} (with a proper description of what is happening) instead of
+   {PATCH}, if the request does not modify the resource in a way defined by
+   the semantics of the media type.
 
-In practice https://tools.ietf.org/html/rfc7396[JSON Merge Patch] quickly turns
-out to be too limited, especially when trying to update single objects in large
-collections (as part of the resource). In this cases
-http://tools.ietf.org/html/rfc6902[JSON Patch] can shown its full power while
-still showing readable patch requests (see also
+In practice {RFC-7396}[JSON Merge Patch] quickly turns out to be too limited,
+especially when trying to update single objects in large collections (as part
+of the resource). In this cases {RFC-6902}[JSON Patch] can shown its full
+power while still showing readable patch requests (see also
 http://erosb.github.io/post/json-patch-vs-merge-patch[JSON patch vs. merge]).
 
 *Note:* Patching the same resource twice is *not* required to be <<idempotent>>

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -47,9 +47,8 @@ You must only use standardized HTTP status codes consistently with their
 intended semantics. You must not invent new HTTP status codes.
 
 RFC standards define ~60 different HTTP status codes with specific semantics 
-(mainly https://tools.ietf.org/html/rfc7231#section-6[RFC7231] and
-https://tools.ietf.org/html/rfc6585[RFC-6585]) — and there are upcoming
-new ones, e.g.
+(mainly {RFC-7231}#section-6[RFC7231] and {RFC-6585}[RFC 6585]) — and there
+are upcoming new ones, e.g.
 https://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-05[draft
 legally-restricted-status]. See overview on all error codes on
 https://en.wikipedia.org/wiki/List_of_HTTP_status_codes[Wikipedia] or

--- a/chapters/hyper-media.adoc
+++ b/chapters/hyper-media.adoc
@@ -160,8 +160,7 @@ See <<pagination>> for information how to best represent paginateable collection
 [#166]
 == {MUST} Not Use Link Headers with JSON entities
 
-We don't allow the use of the
-http://tools.ietf.org/html/rfc5988#section-5[`Link` Header defined by
+We don't allow the use of the {RFC-5988}#section-5[`Link` Header defined by
 RFC 5988] in conjunction with JSON media types. We prefer links directly
 embedded in JSON payloads to the uncommon link header syntax.
 

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -1,16 +1,15 @@
 [[json-guidelines]]
 = JSON Guidelines
 
-These guidelines provides recommendations for defining JSON data at
-Zalando. JSON here refers to
-http://www.rfc-editor.org/rfc/rfc7159.txt[RFC 7159] (which updates
-https://www.ietf.org/rfc/rfc4627.txt[RFC 4627]), the "application/json"
-media type and custom JSON media types defined for APIs. The guidelines
-clarifies some specific cases to allow Zalando JSON data to have an
-idiomatic form across teams and services.
+These guidelines provides recommendations for defining JSON data at Zalando.
+JSON here refers to {RFC-7159}[RFC 7159] (which updates {RFC-4627}[RFC 4627]),
+the "application/json" media type and custom JSON media types defined for APIs.
+The guidelines clarifies some specific cases to allow Zalando JSON data to have
+an idiomatic form across teams and services.
 
-The first some of the following guidelines are about property names,
-the later ones about values.
+The first some of the following guidelines are about property names, the later
+ones about values.
+
 
 [#118]
 == {MUST} Property names must be ASCII snake_case (and never camelCase): `^[a-z_][a-z_0-9]*$`
@@ -26,6 +25,7 @@ companies prefer snake_case: e.g. GitHub, Stack Exchange, Twitter.
 Others, like Google and Amazon, use both - but not only camelCase. It’s
 essential to establish a consistent look and feel such that JSON looks
 as if it came from the same hand.
+
 
 [#216]
 == {SHOULD} Define Maps Using `additionalProperties`
@@ -78,11 +78,13 @@ An actual JSON object described by this might then look like this:
 }
 ```
 
+
 [#120]
 == {SHOULD} Array names should be pluralized
 
 To indicate they contain multiple values prefer to pluralize array
 names. This implies that object names should in turn be singular.
+
 
 [#122]
 == {MUST} Boolean property values must not be null
@@ -95,34 +97,34 @@ or statuses - for example accepted_terms_and_conditions with true or
 false can be replaced with terms_and_conditions with values yes, no and
 unknown.
 
+
 [#123]
 == {SHOULD} Null values should have their fields removed
 
-OpenAPI, which is in common use, doesn't support null field
-values (it does allow omitting that field completely if it is not marked
-as required). However that doesn't prevent clients and servers sending
-and receiving those fields with null values. Also, in some cases null
-may be a meaningful value - for example, JSON Merge Patch
-https://tools.ietf.org/html/rfc7386[RFC 7382]) using null to indicate
+OpenAPI, which is in common use, doesn't support null field values (it does
+allow omitting that field completely if it is not marked as required).
+However that doesn't prevent clients and servers sending and receiving those
+fields with null values. Also, in some cases null may be a meaningful value
+- for example, JSON Merge Patch {RFC-7396}[RFC 7396]) using null to indicate
 property deletion.
+
 
 [#124]
 == {SHOULD} Empty array values should not be null
 
-Empty array values can unambiguously be represented as the empty
-list, `[]`.
+Empty array values can unambiguously be represented as the empty list, `[]`.
+
 
 [#125]
 == {SHOULD} Enumerations should be represented as Strings
 
-Strings are a reasonable target for values that are by design
-enumerations.
+Strings are a reasonable target for values that are by design enumerations.
+
 
 [#126]
 == {SHOULD} Date property values should conform to RFC 3339
 
-Use the date and time formats defined by
-http://tools.ietf.org/html/rfc3339#section-5.6[RFC 3339]:
+Use the date and time formats defined by {RFC-3339}#section-5.6[RFC 3339]:
 
 * for "date" use strings matching
 `date-fullyear "-" date-month "-" date-mday`, for example: `2015-05-28`
@@ -134,7 +136,7 @@ https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-ty
 format] "date-time" corresponds to "date-time" in the RFC) and
 `2015-05-28` for a date (note that the OpenAPI format "date" corresponds
 to "full-date" in the RFC). Both are specific profiles, a subset of the
-international standard http://en.wikipedia.org/wiki/ISO_8601[ISO 8601].
+international standard {ISO-8601}[ISO 8601].
 
 A zone offset may be used (both, in request and responses) -- this is
 simply defined by the standards. However, we encourage restricting dates
@@ -155,21 +157,23 @@ timestamps, but this can introduce interpretation issues with precision
 1460062925000 or 1460062925.000. Date strings, though more verbose and
 requiring more effort to parse, avoid this ambiguity.
 
+
 [#127]
 == {MAY} Time durations and intervals could conform to ISO 8601
 
 Schema based JSON properties that are by design durations and intervals
-could be strings formatted as recommended by ISO 8601
-(https://tools.ietf.org/html/rfc3339#appendix-A[Appendix A of RFC 3339
-contains a grammar] for durations).
+could be strings formatted as recommended by {ISO-8601}[ISO 8601]
+({RFC-3339}#appendix-A[Appendix A of RFC 3339 contains a grammar] for
+durations).
+
 
 [#128]
 == {MAY} Standards could be used for Language, Country and Currency
 
-* http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2[ISO 3166-1-alpha2 country]
+* {ISO-3166-1-a2}[ISO 3166-1-alpha2 country]
 * (It's "GB", not "UK", even though "UK" has seen some use at Zalando)
-* https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes[ISO 639-1 language code]
-* https://tools.ietf.org/html/bcp47[BCP-47] (based on ISO 639-1) for language variants
-* http://en.wikipedia.org/wiki/ISO_4217[ISO 4217 currency codes]
-
+* {ISO-639-1}[ISO 639-1 language code]
+* https://tools.ietf.org/html/bcp47[BCP-47] (based on {ISO-639-1}[ISO 639-1])
+  for language variants
+* {ISO-4217}[ISO 4217 currency codes]
 

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -114,8 +114,7 @@ Disposition-Notification-Options
 Original-Message-ID
 ----
 
-See also: http://tools.ietf.org/html/rfc7230#page-22[HTTP Headers are
-case-insensitive (RFC 7230)].
+See also: {RFC-7230}#page-22[HTTP Headers are case-insensitive (RFC 7230)].
 
 See <<common-headers>> and <<proprietary-headers>> sections for more guidance
 on HTTP headers.

--- a/chapters/proprietary-headers.adoc
+++ b/chapters/proprietary-headers.adoc
@@ -22,21 +22,18 @@ operation should always be expressed by URLs path and query parameters,
 the method, and the content. Headers are more often used to implement
 functions close to the protocol considerations, such as flow control,
 content negotiation, and authentication. Thus, headers are reserved for
-general context information
-(https://tools.ietf.org/html/rfc7231#section-5[RFC-7231]).
+general context information ({RFC-7231#section-5[RFC 7231]).
 
-`X-` headers were initially reserved for unstandardized parameters, but
-the usage of `X-` headers is deprecated
-(https://tools.ietf.org/html/rfc6648[RFC-6648]). This complicates the
-contract definition between consumer and producer of an API following
+`X-` headers were initially reserved for unstandardized parameters, but the
+usage of `X-` headers is deprecated ({RFC-6648}[RFC 6648]). This complicates
+the contract definition between consumer and producer of an API following
 these guidelines, since there is no aligned way of using those headers.
 Because of this, the guidelines restrict which `X-` headers can be used
 and how they are used.
 
-The Internet Engineering Task Force's states in
-https://tools.ietf.org/html/rfc6648[RFC-6648] that company specific
-header' names should incorporate the organization's name. We aim for
-backward compatibility, and therefore keep the `X-` prefix.
+The Internet Engineering Task Force's states in {RFC-6648}[RFC 6648] that
+company specific header' names should incorporate the organization's name.
+We aim for backward compatibility, and therefore keep the `X-` prefix.
 
 The following proprietary headers have been specified by this guideline
 for usage so far. Remember that HTTP header field names are not
@@ -99,32 +96,31 @@ hop-by-hop `X-RateLimit-` headers which can be used as defined in <<153>>.
 == {MUST} Propagate Proprietary Headers
 
 All Zalando's proprietary headers are end-to-end headers.
-footnoteref:[header-types, HTTP/1.1 standard
-(https://tools.ietf.org/html/rfc7230#section-6.1[RFC-7230]) defines two
-types of headers: end-to-end and hop-by-hop headers. End-to-end headers
-must be transmitted to the ultimate recipient of a request or response.
-Hop-by-hop headers, on the contrary, are meaningful for a single
-connection only.]
+footnoteref:[header-types, HTTP/1.1 standard ({RFC-7230}#section-6.1[RFC 7230])
+defines two types of headers: end-to-end and hop-by-hop headers. End-to-end
+headers must be transmitted to the ultimate recipient of a request or response.
+Hop-by-hop headers, on the contrary, are meaningful for a single connection
+only.]
 
-All headers specified above must be propagated to the services down the
-call chain. The header names and values must remain unchanged.
+All headers specified above must be propagated to the services down the call
+chain. The header names and values must remain unchanged.
 
-For example, the values of the custom headers like `X-Device-Type` can
-affect the results of queries by using device type information to
-influence recommendation results. Besides, the values of the custom
-headers can influence the results of the queries (e.g. the device type
-information influences the recommendation results).
+For example, the values of the custom headers like `X-Device-Type` can affect
+the results of queries by using device type information to influence
+recommendation results. Besides, the values of the custom headers can influence
+the results of the queries (e.g. the device type information influences the
+recommendation results).
 
-Sometimes the value of a proprietary header will be used as part of the
-entity in a subsequent request. In such cases, the proprietary headers
-must still be propagated as headers with the subsequent request, despite
-the duplication of information.
+Sometimes the value of a proprietary header will be used as part of the entity
+in a subsequent request. In such cases, the proprietary headers must still be
+propagated as headers with the subsequent request, despite the duplication of
+information.
 
 [#233]
 == {MUST} Use `X-Flow-ID`
 
-The *Flow-Id* is a generic parameter to be passed through service APIs and events
-and written into log files and traces. A consequent usage of the
+The *Flow-Id* is a generic parameter to be passed through service APIs and
+events and written into log files and traces. A consequent usage of the
 *Flow-Id* facilitates the tracking of call flows through our system and allows
 the correlation of service activities initiated by a specific call. This is
 extremely helpful for operational troubleshooting and log analysis. Main use
@@ -144,7 +140,8 @@ to the character set `[a-zA-Z0-9/+]` (Base64).
 
 *Note:* If a legacy subsystem can only process _Flow-Ids_ with a specific
 format or length, it must define this restrictions in its API specification,
-and be generous and remove invalid characters or cut the length to the supported limit.
+and be generous and remove invalid characters or cut the length to the
+supported limit.
 
 *Hint:* In case distributed tracing is supported by {SRE-Tracing}[OpenTracing
 (internal link)] you should ensure that created _spans_ are tagged using

--- a/chapters/references.adoc
+++ b/chapters/references.adoc
@@ -4,41 +4,56 @@
 
 This section collects links to documents to which we refer, and base our guidelines on.
 
+
 [[openapi-specification]]
 == OpenAPI Specification
 
-* https://github.com/OAI/OpenAPI-Specification/[OpenAPI Specification]
+* *https://github.com/OAI/OpenAPI-Specification/[OpenAPI Specification]*
+* *https://openapi-map.apihandyman.io/[OpenAPI Specification Mind Map]*
+
 
 [[publications-specifications-and-standards]]
 == Publications, specifications and standards
 
-* https://tools.ietf.org/html/rfc3339[RFC 3339: Date and Time on the Internet: Timestamps]
-* https://tools.ietf.org/html/rfc5988[RFC 5988: Web Linking]
-* https://tools.ietf.org/html/rfc7159[RFC 7159: The JavaScript Object Notation (JSON) Data Interchange Format]
-* https://tools.ietf.org/html/rfc7230[RFC 7230: Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing]
-* https://tools.ietf.org/html/rfc7231[RFC 7231: Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content]
-* https://tools.ietf.org/html/rfc7807[RFC 7807: Problem Details for HTTP APIs]
-* https://en.wikipedia.org/wiki/ISO_8601[ISO 8601: Date and time format]
-* https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2[ISO 3166-1 alpha-2: Two letter country codes]
-* https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes[ISO 639-1: Two letter language codes]
-* https://en.wikipedia.org/wiki/ISO_4217[ISO 4217: Currency codes]
-* https://tools.ietf.org/html/bcp47[BCP 47: Tags for Identifying Languages]
+* *{RFC-3339}[RFC 3339]:* Date and Time on the Internet: Timestamps
+* *{RFC-4122}[RFC 4122]:* A Universally Unique IDentifier (UUID) URN Namespace
+* *{RFC-4627}[RFC 4627]:* The application/json Media Type for JavaScript Object Notation (JSON)
+* *{RFC-5988}[RFC 5988]:* Web Linking
+* *{RFC-6585}[RFC 6585]:* Additional HTTP Status Codes
+* *{RFC-6902}[RFC 6902]:* JavaScript Object Notation (JSON) Patch
+* *{RFC-7159}[RFC 7159]:* The JavaScript Object Notation (JSON) Data Interchange Format
+* *{RFC-7230}[RFC 7230]:* Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing
+* *{RFC-7231}[RFC 7231]:* Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content
+* *{RFC-7232}[RFC 7232]:* Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests
+* *{RFC-7233}[RFC 7233]:* Hypertext Transfer Protocol (HTTP/1.1): Range Requests
+* *{RFC-7234}[RFC 7234]:* Hypertext Transfer Protocol (HTTP/1.1): Caching
+* *{RFC-7240}[RFC 7240]:* Prefer Header for HTTP
+* *{RFC-7396}[RFC 7396]:* JSON Merge Patch
+* *{RFC-7807}[RFC 7807]:* Problem Details for HTTP APIs
+
+* *{ISO-8601}[ISO 8601]:* Date and time format
+* *{ISO-3166-1-a2}[ISO 3166-1 alpha-2]:* Two letter country codes
+* *{ISO-639-1}[ISO 639-1]:* Two letter language codes
+* *{ISO-4217}[ISO 4217]:* Currency codes
+* *https://tools.ietf.org/html/bcp47[BCP 47]:* Tags for Identifying Languages
 
 [[dissertations]]
 == Dissertations
 
-* http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm[Roy Thomas Fielding - Architectural Styles and the Design of Network-Based Software Architectures]. This is the text which defines what REST is.
+* *http://www.ics.uci.edu/~fielding/pubs/dissertation/top.htm[Roy Thomas
+  Fielding - Architectural Styles and the Design of Network-Based Software
+  Architectures]:* This is the text which defines what REST is.
 
 [[books]]
 == Books
 
-* http://www.amazon.de/REST-Practice-Hypermedia-Systems-Architecture/dp/0596805829[REST in Practice: Hypermedia and Systems Architecture]
-* https://leanpub.com/build-apis-you-wont-hate[Build APIs You Won't Hate]
-* http://www.infoq.com/minibooks/emag-web-api[InfoQ eBook - Web APIs: From Start to Finish]
+* *http://www.amazon.de/REST-Practice-Hypermedia-Systems-Architecture/dp/0596805829[REST in Practice: Hypermedia and Systems Architecture]*
+* *https://leanpub.com/build-apis-you-wont-hate[Build APIs You Won't Hate]*
+* *http://www.infoq.com/minibooks/emag-web-api[InfoQ eBook - Web APIs: From Start to Finish]*
 
 [[blogs]]
 == Blogs
 
-* http://restful-api-design.readthedocs.org/en/latest/[Lessons-learned blog: Thoughts on RESTful API Design]
+* *http://restful-api-design.readthedocs.org/en/latest/[Lessons-learned blog: Thoughts on RESTful API Design]*
 
 

--- a/chapters/tooling.adoc
+++ b/chapters/tooling.adoc
@@ -5,34 +5,44 @@
 This is not a part of the actual guidelines, but might be helpful for following them.
 Using a tool mentioned here doesn't automatically ensure you follow the guidelines.
 
+
 [[api-first-integrations]]
 == API First Integrations
 
 The following frameworks were specifically designed to support the API First workflow with OpenAPI YAML files (sorted alphabetically):
 
-* https://github.com/zalando/connexion[Connexion: OpenAPI First framework for Python on top of Flask]
-* https://github.com/zalando-stups/friboo[Friboo: utility library to write microservices in Clojure with support for Swagger and OAuth]
-* https://github.com/zalando/api-first-hand[Api-First-Hand: API-First Play Bootstrapping Tool for Swagger/OpenAPI specs]
-* https://github.com/swagger-api/swagger-codegen[Swagger Codegen: template-driven engine to generate client code in different languages by parsing Swagger Resource Declaration]
-* https://github.com/zalando-stups/swagger-codegen-tooling[Swagger Codegen Tooling: plugin for Maven that generates pieces of code from
-OpenAPI specification]
-* https://github.com/zalando/intellij-swagger[Swagger Plugin for IntelliJ IDEA: plugin to help you easily edit Swagger specification
-files inside IntelliJ IDEA]
+* *https://github.com/zalando/connexion[Connexion]:*
+  OpenAPI First framework for Python on top of Flask
+* *https://github.com/zalando-stups/friboo[Friboo]:*
+  utility library to write microservices in Clojure with support for Swagger and OAuth
+* *https://github.com/zalando/api-first-hand[Api-First-Hand]:*
+  API-First Play Bootstrapping Tool for Swagger/OpenAPI specs
+* *https://github.com/swagger-api/swagger-codegen[Swagger Codegen]:*
+  template-driven engine to generate client code in different languages by
+  parsing Swagger Resource Declaration
+* *https://github.com/zalando-stups/swagger-codegen-tooling[Swagger Codegen Tooling]:*
+  plugin for Maven that generates pieces of code from OpenAPI specification
+* *https://github.com/zalando/intellij-swagger[Swagger Plugin for IntelliJ IDEA]:*
+  plugin to help you easily edit Swagger specification files inside IntelliJ IDEA
 
 The Swagger/OpenAPI homepage lists more
 http://swagger.io/open-source-integrations/[Community-Driven Language Integrations], but most of them do not fit our API First approach.
+
 
 [[support-libraries]]
 == Support Libraries
 
 These utility libraries support you in implementing various parts of our RESTful API guidelines (sorted alphabetically):
 
-* https://github.com/zalando/problem[Problem: Java library that implements application/problem+json]
-* https://github.com/zalando/problem-spring-web[Problems for Spring Web MVC: library for handling Problems in Spring Web MVC]
-* https://github.com/zalando/jackson-datatype-money[Jackson Datatype Money: extension module to properly support datatypes of javax.money]
-* https://github.com/zalando-incubator/json-fields[JSON fields: framework for limiting fields of JSON objects exposed by Rest APIs]
-* https://github.com/zalando/tracer[Tracer: call tracing and log correlation in distributed systems]
-* https://github.com/zalando-stups/twintip-crawler[TWINTIP: API definition crawler for the STUPS ecosystem]
-* https://github.com/zalando/twintip-spring-web[TWINTIP Spring Integration: API discovery endpoint for Spring Web MVC]
-
-
+* *https://github.com/zalando/problem[Problem]:*
+  Java library that implements application/problem+json
+* *https://github.com/zalando/problem-spring-web[Problems for Spring Web MVC]:*
+  library for handling Problems in Spring Web MVC
+* *https://github.com/zalando/jackson-datatype-money[Jackson Datatype Money]:*
+  extension module to properly support datatypes of javax.money
+* *https://github.com/zalando-incubator/json-fields[JSON fields]:*
+  framework for limiting fields of JSON objects exposed by Rest APIs
+* *https://github.com/zalando/tracer[Tracer]:*
+  call tracing and log correlation in distributed systems
+* *https://github.com/zalando/twintip-spring-web[TWINTIP Spring Integration]:*
+  API discovery endpoint for Spring Web MVC

--- a/index.adoc
+++ b/index.adoc
@@ -13,15 +13,29 @@
 
 
 // Some link short cuts.
+:RFC-3339: https://tools.ietf.org/html/rfc3339
 :RFC-4122: https://tools.ietf.org/html/rfc4122
+:RFC-4627: https://tools.ietf.org/html/rfc4627
+:RFC-5988: https://tools.ietf.org/html/rfc5988
 :RFC-6585: https://tools.ietf.org/html/rfc6585
+:RFC-6648: https://tools.ietf.org/html/rfc6648
+:RFC-6838: https://tools.ietf.org/html/rfc6838
+:RFC-6902: https://tools.ietf.org/html/rfc6902
+:RFC-7159: https://tools.ietf.org/html/rfc7159
 :RFC-7230: https://tools.ietf.org/html/rfc7230
 :RFC-7231: https://tools.ietf.org/html/rfc7231
 :RFC-7232: https://tools.ietf.org/html/rfc7232
 :RFC-7233: https://tools.ietf.org/html/rfc7233
 :RFC-7234: https://tools.ietf.org/html/rfc7234
 :RFC-7240: https://tools.ietf.org/html/rfc7240
+:RFC-7396: https://tools.ietf.org/html/rfc7396
 :RFC-7807: https://tools.ietf.org/html/rfc7807
+
+
+:ISO-8601: https://en.wikipedia.org/wiki/ISO_8601
+:ISO-3166-1-a2: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+:ISO-639-1: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+:ISO-4217: https://en.wikipedia.org/wiki/ISO_4217
 
 :SRE-Tracing: https://github.bus.zalan.do/SRE/opentracing
 


### PR DESCRIPTION
This is a majorly editorial update.

1. I applied the references for RFC and ISO links consistently in the document.
2. I updated the references and the tooling section to have a slightly different look and feel.
3. I removed the references to the not any longer existing repository for the twintip-crawler.
4. I added references to RFCs we are referencing in our guideline.
5. I updated some RFC references to point to the latest version of the document.