### PR TITLE
feat: add HEAD for response status code 304 (#501)

### DIFF
--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -117,7 +117,7 @@ See Other - The response to the request can be found under another URI using a
 |[[status-code-304]]{304}|
 Not Modified - resource has not been modified since the date or version passed
 via request headers If-Modified-Since or If-None-Match.
-|{GET}
+|{GET}, {HEAD}
 |=======================================================================
 
 [[client-side-error-codes]]


### PR DESCRIPTION
fixes #501. Adding `HEAD` for status code `304` as mentioned in [RFC 7232 Section 4.1](https://tools.ietf.org/html/rfc7232#section-4.1).