### PR TITLE
feat: improve prefer header specification (#503)

### DIFF
--- a/chapters/best-practices.adoc
+++ b/chapters/best-practices.adoc
@@ -218,5 +218,5 @@ later than the given date:
   not perfectly in sync, the locking could potentially fail
 
 === Conclusion
-We suggest to either use the _{ETags} in result entities_ or _{Last-Modified}
+We suggest to either use the _{ETag} in result entities_ or _{Last-Modified}
 / {If-Unmodified-Since}_ approach.

--- a/chapters/common-headers.adoc
+++ b/chapters/common-headers.adoc
@@ -95,7 +95,7 @@ The {Prefer} header can defined like this in an API definition:
 components:
   headers:
   - Prefer:
-      description: |
+      description: >
         The RFC7240 Prefer header indicates that a particular server behavior
         is preferred by the client but is not required for successful completion
         of the request (see [RFC 7240](https://tools.ietf.org/html/rfc7240).
@@ -110,16 +110,25 @@ components:
           resource (representation) in the response body on success.
         * **wait=<delta-seconds>** is used to suggest a maximum time the server
           has time to process the request synchronously.
-        * **handling=<strinct|lenient>** is used to suggest the server to be
+        * **handling=<strict|lenient>** is used to suggest the server to be
           strict and report error conditions or lenient, i.e. robust and try to
           continue, if possible.
 
-      type: string
+      type: array
+      style: form
+      items:
+        type: string
       required: false
 ----
 
+*Note:* Please copy only the behaviors into your {Prefer} header specification
+that are supported by your API endpoint. If necessary, specify different
+{Prefer} headers for each supported use case.
+
 Supporting APIs may return the {Preference-Applied} header also defined in
 {RFC7240}[RFC 7240] to indicate whether a preference has been applied.
+
+
 
 [#182]
 == {MAY} Consider to Support `ETag` Together With `If-Match`/`If-None-Match` Header

--- a/chapters/common-headers.adoc
+++ b/chapters/common-headers.adoc
@@ -125,7 +125,7 @@ that are supported by your API endpoint. If necessary, specify different
 {Prefer} headers for each supported use case.
 
 Supporting APIs may return the {Preference-Applied} header also defined in
-{RFC7240}[RFC 7240] to indicate whether a preference has been applied.
+{RFC-7240}[RFC 7240] to indicate whether a preference has been applied.
 
 
 

--- a/chapters/common-headers.adoc
+++ b/chapters/common-headers.adoc
@@ -115,7 +115,6 @@ components:
           continue, if possible.
 
       type: array
-      style: form
       items:
         type: string
       required: false

--- a/chapters/compatibility.adoc
+++ b/chapters/compatibility.adoc
@@ -81,8 +81,8 @@ providers:
   either be agnostic or provide default behavior for unknown values.
 * Be prepared to handle HTTP status codes not explicitly specified in endpoint
   definitions. Note also, that status codes are extensible. Default handling is
-  how you would treat the corresponding {x00} code (see {RFC7231}#section-6[RFC
-  7231 Section 6]).
+  how you would treat the corresponding {x00} code (see
+  {RFC-7231}#section-6[RFC 7231 Section 6]).
 * Follow the redirect when the server returns HTTP status code {301} (Moved
   Permanently).
 

--- a/chapters/deprecation.adoc
+++ b/chapters/deprecation.adoc
@@ -55,10 +55,16 @@ uncontrolled breaking effects. See also the <<193>>.
 During deprecation phase, the producer should add a `Warning` header (see
 {RFC-7234}#section-5.5[RFC 7234 - Warning header]) field. When adding the
 `Warning` header, the `warn-code` must be `299` and the `warn-text` should be
-in form of _"The path/operation/parameter/... \{name} is deprecated and will
-be removed by \{date}. Please see \{link} for details."_ with a link to a
-documentation describing why the API is no longer supported in the
-current form and what clients should do about it. Adding the `Warning`
+in form of 
+
+[source,txt]
+----
+The path/operation/parameter/... {name} is deprecated and will be removed by {date}.
+Please see {link} for details.
+----
+
+with a link to a documentation describing why the API is no longer supported
+in the current form and what clients should do about it. Adding the `Warning`
 header is not sufficient to gain client consent to shut down an API.
 
 [#190]

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -257,7 +257,7 @@ response processing this distinction normally does not matter.
 
 APIs that wish to manage the request rate of clients must use the {429} (Too
 Many Requests) response code, if the client exceeded the request rate (see
-{RFC-6586}[RFC 6585]). Such responses must also contain header information
+{RFC-6585}[RFC 6585]). Such responses must also contain header information
 providing further details to the client. There are two approaches a service
 can take for header information:
 

--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -139,7 +139,7 @@ the Open API specification and must conform to the following specification:
 
 [source,yaml]
 ----
-#/info/x-audience:
+/info/x-audience:
   type: string
   x-extensible-enum:
     - component-internal

--- a/chapters/performance.adoc
+++ b/chapters/performance.adoc
@@ -217,7 +217,8 @@ following rules:
    this is not supported by generic client and proxy caches on HTTP layer.
 
 *Hint:* For proper cache support, you must return {304} without content on a
-failed {HEAD} or {GET} request with `If-None-Match: <entity-tag>` instead of {412}.
+failed {HEAD} or {GET} request with  <<182, `If-None-Match: <entity-tag>`>> instead
+of {412}.
 
 [source,yaml]
 ----

--- a/chapters/proprietary-headers.adoc
+++ b/chapters/proprietary-headers.adoc
@@ -22,7 +22,7 @@ operation should always be expressed by URLs path and query parameters,
 the method, and the content. Headers are more often used to implement
 functions close to the protocol considerations, such as flow control,
 content negotiation, and authentication. Thus, headers are reserved for
-general context information ({RFC-7231#section-5[RFC 7231]).
+general context information ({RFC-7231}#section-5[RFC 7231]).
 
 `X-` headers were initially reserved for unstandardized parameters, but the
 usage of `X-` headers is deprecated ({RFC-6648}[RFC 6648]). This complicates
@@ -130,20 +130,20 @@ propagated as headers with the subsequent request, despite the duplication of
 information.
 
 [#233]
-== {MUST} Use `X-Flow-ID`
+== {MUST} Support `X-Flow-ID`
 
-The *Flow-Id* is a generic parameter to be passed through service APIs and
+The _Flow-ID_ is a generic parameter to be passed through service APIs and
 events and written into log files and traces. A consequent usage of the
-*Flow-Id* facilitates the tracking of call flows through our system and allows
+_Flow-ID_ facilitates the tracking of call flows through our system and allows
 the correlation of service activities initiated by a specific call. This is
 extremely helpful for operational troubleshooting and log analysis. Main use
-case of *Flow-Id* is to track service calls of our SaaS fashion commerce
+case of _Flow-ID_ is to track service calls of our SaaS fashion commerce
 platform and initiated internal processing flows (executed synchronously via
 APIs or asynchronously via published events).
 
 *Data Definition*
 
-The *Flow-Id* must be passed through:
+The _Flow-ID_ must be passed through:
 
 * RESTful API requests via {X-Flow-ID} proprietary header (see <<184>>)
 * Published events via `flow_id` event field (see <<event-metadata, metadata>>)
@@ -151,7 +151,7 @@ The *Flow-Id* must be passed through:
 It must be an random unique string consisting of maximal 128 chars, restricted
 to the character set `[a-zA-Z0-9/+]` (Base64). 
 
-*Note:* If a legacy subsystem can only process _Flow-Ids_ with a specific
+*Note:* If a legacy subsystem can only process _Flow-IDs_ with a specific
 format or length, it must define this restrictions in its API specification,
 and be generous and remove invalid characters or cut the length to the
 supported limit.
@@ -160,22 +160,22 @@ supported limit.
 (internal link)] you should ensure that created _spans_ are tagged using
 `flow_id` — see
 {SRE-Tracing}/blob/master/wg-semantic-conventions/best-practices/flowid.md[How
-to Connect Log Output with OpenTracing Using FlowIDs (internal link)] or
+to Connect Log Output with OpenTracing Using Flow-IDs (internal link)] or
 {SRE-Tracing}/blob/master/wg-semantic-conventions/best-practices.md[Best
 practises (internal link)].
 
 *Service Guidance*
 
-* Services *must* support _Flow-Id_ as generic input, i.e.
+* Services *must* support _Flow-ID_ as generic input, i.e.
 ** RESTful API endpoints *must* support {X-Flow-ID} header in requests
 ** Event listeners *must* support the metadata `flow-id` from events.
 
 +
-*Note:*  API-Clients *must* provide _Flow-Id_ when calling a service or
-producing events. If no _Flow-Id_ is provided in a request or event, the
-service must create a new _Flow-Id_.
+*Note:*  API-Clients *must* provide _Flow-ID_ when calling a service or
+producing events. If no _Flow-ID_ is provided in a request or event, the
+service must create a new _Flow-ID_.
 
-* Services *must* propagate _Flow-Id_, i.e. use _Flow-Id_ received
+* Services *must* propagate _Flow-ID_, i.e. use _Flow-ID_ received
 with API-Calls or consumed events as...
 ** input for all API called and events published during processing
 ** data field written for logging and tracing

--- a/index.adoc
+++ b/index.adoc
@@ -66,6 +66,7 @@
 
 
 // Attributes to improve design and linking of HTTP status codes
+:x00: pass:[<a href="#http-status-codes-and-errors" class="status-code">2xx</a>]
 :2xx: pass:[<a href="#success-codes" class="status-code">2xx</a>]
 :3xx: pass:[<a href="#redirection-codes" class="status-code">3xx</a>]
 :4xx: pass:[<a href="#client-side-error-codes" class="status-code">4xx</a>]
@@ -105,6 +106,7 @@
 :X-Frontend-Type: pass:[<a href="#x-frontend-type"><code>X-Frontend-Type</code></a>]
 :X-Device-Type: pass:[<a href="#x-device-type"><code>X-device-Type</code></a>]
 :X-Device-OS: pass:[<a href="#x-device-os"><code>X-device-OS</code></a>]
+:X-Mobile-Advertising-ID: pass:[<a href="#x-mobile-advertising-id"><code>X-Mobile-Advertising-ID</code></a>]
 :X-App-Domain: pass:[<a href="#x-app-domain"><code>X-App-Domain</code></a>]
 
 :x-extensible-enum: pass:[<a href="#112"><code>x-extensible-enum</code></a>]
@@ -142,8 +144,8 @@
 :Retry-After: pass:[<a href="https://tools.ietf.org/html/rfc7231#section-7.1.3"><code>Retry-After</code></a>]
 :Vary: pass:[<a href="https://tools.ietf.org/html/rfc7231#section-7.1.4"><code>Vary</code></a>]
 :Cache-Control: pass:[<a href="https://tools.ietf.org/html/rfc7234#section-5.2"><code>Cache-Control</code></a>]
-:Cache-Control#no-store: pass:[<a href="https://tools.ietf.org/html/rfc7234#section-5.2.2.2"><code>Cache-Control: no-store</code></a>]
-
+:Cache-Control-no-store: pass:[<a href="https://tools.ietf.org/html/rfc7234#section-5.2.2.2"><code>Cache-Control: no-store</code></a>]
+:Expires: pass:[<a href="https://tools.ietf.org/html/rfc7234#section-5.3"><code>Expires</code></a>]
 
 // Attributes to improve design and linking of RFC key words.
 :RFC-safe: pass:[<a href="https://tools.ietf.org/html/rfc7231#section-4.2.1">safe</a>]


### PR DESCRIPTION
fixes #502. Fixed spelling. Added note to copy only supported behaviors after reviewing an API that copied the full template and adding a separate description to restrict the supported use cases instead of striping down the template.

In addition, I have put some broken link and visual fixes into this pull request, that we stumbled over during the review of @maxim-tschumak.