### PR TITLE
Remove X-App-Domain

### DIFF
--- a/chapters/proprietary-headers.adoc
+++ b/chapters/proprietary-headers.adoc
@@ -95,11 +95,6 @@ parameter through when calling other services. It is not sent if the customer
 disables it in the settings for respective mobile platform.
 |b89fadce-1f42-46aa-9c83-b7bc49e76e1f
 
-|[[x-app-domain]]{X-App-Domain}|Integer|
-The app domain (i.e. shop channel context) of the request. Note, app-domain is
-a legacy concept that will be replaced in new platform by combinations of main
-CFA concerns like retailer, sales channel, country
-|16
 |=======================================================================
 
 *Exception:* The only exception to this guideline are the conventional


### PR DESCRIPTION
This concept is legacy inside Zalando and having this header implicitly passed around makes it harder to move away from it.