### PR TITLE
feat: correct rule 154 (#505)

### DIFF
--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -331,19 +331,36 @@ original one implementing a well defined behavior. Using {204} without content
 would be a similar well defined option.
 
 [#154]
-== {SHOULD} Define Collection Format of Query Parameters and Headers
+== {MUST} Define Collection Format of Query Parameters and Headers
 
-Sometimes, query parameters and headers allow to provide a list of values,
-either by providing a comma-separated list (`csv`) or by repeating the
-parameter multiple times with different values (`multi`). The API
-specification should explicitly define one type as follows:
+Header, path, and query parameters  allow to provide a collection of values,
+either by providing a comma-separated list of values (`csv`) or by repeating
+the parameter multiple times with different values (`multi`) as follows:
 
-[,cols="20%,20%,25%,35%",options="header",]
-|=======================================================================
-|Description |OpenAPI 3.0 |OpenAPI 2.0 |Example
-|Comma separated values |`style: form, explode: false` |`collectionFormat: csv` |`?param=value1,value2`
-|Multiple parameters |`style: form, explode: true` |`collectionFormat: multi` |`?param=value1&param=value2`
-|=======================================================================
+[,cols="14%,30%,39%,17%",options="header",]
+|=========================================================================
+| Parameter Type | Comma-separated Values | Multiple Parameters | Standard
+| Header | `Header: value1,value2` | `Header: value1, Header: value2`
+| {RFC-7230}#section-3.2.2[RFC 7230 Section 3.2.2]
+
+| Path | `key=value1,value2` | `/key=value1;key=value2`
+| {RFC-6570}#section-3.2.7[RFC 6570 Section 3.2.7]
+
+| Query | `?param=value1,value2` | `?param=value1&param=value2`
+| {RFC-6570}#section-3.2.8[RFC 6570 Section 3.2.8]
+|=========================================================================
+
+As Open API does not support both schemas at once, an API specification must
+explicitly define the collection format to guide consumers as follows:
+
+[,cols="14%,40%,46%",options="header",]
+|===============================================================
+| Parameter Type | Comma-separated Values | Multiple Parameters
+| Header | `style: simple, explode: false` | not allowed (see
+  {RFC-7230}#section-3.2.2[RFC 7230 Section 3.2.2])
+| Path   | `style: simple, explode: false` | `style: simple, explode: true`
+| Query  | `style: form, explode: false`   | `style: form, explode: true`
+|===============================================================
 
 When choosing the collection format, take into account the tool support,
 the escaping of special characters and the maximal URL length.

--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -331,11 +331,11 @@ original one implementing a well defined behavior. Using {204} without content
 would be a similar well defined option.
 
 [#154]
-== {MUST} Define Collection Format of Query Parameters and Headers
+== {MUST} Define Collection Format of Header, Path, and Query Parameters
 
 Header, path, and query parameters  allow to provide a collection of values,
-either by providing a comma-separated list of values (`csv`) or by repeating
-the parameter multiple times with different values (`multi`) as follows:
+either by providing a comma-separated list of values or by repeating the
+parameter multiple times with different values as follows:
 
 [,cols="14%,30%,39%,17%",options="header",]
 |=========================================================================

--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -331,20 +331,17 @@ original one implementing a well defined behavior. Using {204} without content
 would be a similar well defined option.
 
 [#154]
-== {MUST} Define Collection Format of Header, Path, and Query Parameters
+== {MUST} Define Collection Format of Header and Query Parameters
 
-Header, path, and query parameters  allow to provide a collection of values,
-either by providing a comma-separated list of values or by repeating the
-parameter multiple times with different values as follows:
+Header and query parameters allow to provide a collection of values, either
+by providing a comma-separated list of values or by repeating the parameter
+multiple times with different values as follows:
 
 [,cols="14%,30%,39%,17%",options="header",]
 |=========================================================================
 | Parameter Type | Comma-separated Values | Multiple Parameters | Standard
 | Header | `Header: value1,value2` | `Header: value1, Header: value2`
 | {RFC-7230}#section-3.2.2[RFC 7230 Section 3.2.2]
-
-| Path | `key=value1,value2` | `/key=value1;key=value2`
-| {RFC-6570}#section-3.2.7[RFC 6570 Section 3.2.7]
 
 | Query | `?param=value1,value2` | `?param=value1&param=value2`
 | {RFC-6570}#section-3.2.8[RFC 6570 Section 3.2.8]
@@ -358,7 +355,6 @@ explicitly define the collection format to guide consumers as follows:
 | Parameter Type | Comma-separated Values | Multiple Parameters
 | Header | `style: simple, explode: false` | not allowed (see
   {RFC-7230}#section-3.2.2[RFC 7230 Section 3.2.2])
-| Path   | `style: simple, explode: false` | `style: simple, explode: true`
 | Query  | `style: form, explode: false`   | `style: form, explode: true`
 |===============================================================
 

--- a/index.adoc
+++ b/index.adoc
@@ -17,6 +17,7 @@
 :RFC-4122: https://tools.ietf.org/html/rfc4122
 :RFC-4627: https://tools.ietf.org/html/rfc4627
 :RFC-5988: https://tools.ietf.org/html/rfc5988
+:RFC-6570: https://tools.ietf.org/html/rfc6570
 :RFC-6585: https://tools.ietf.org/html/rfc6585
 :RFC-6648: https://tools.ietf.org/html/rfc6648
 :RFC-6838: https://tools.ietf.org/html/rfc6838


### PR DESCRIPTION
fixes #505.

In addition, this pull request suggests that users explicitly *must* define the collection format. The OpenAPI specification 2.0 was dropped, to foster migration to 3.0.x after supporting it now for nearly a year as default.