### PR TITLE
Made using the money object a MUST rule

### DIFF
--- a/chapters/common-data-types.adoc
+++ b/chapters/common-data-types.adoc
@@ -4,7 +4,7 @@
 Definitions of data objects that are good candidates for wider usage:
 
 [#173]
-== {SHOULD} Use a Common Money Object
+== {MUST} Use a Common Money Object
 
 Use the following common money structure:
 


### PR DESCRIPTION
I don't see a good reason why someone wouldn't use the `Money` object as a representation of monetary amounts. 