### PR TITLE
Update Flow-ID rule

### DIFF
--- a/chapters/proprietary-headers.adoc
+++ b/chapters/proprietary-headers.adoc
@@ -147,8 +147,12 @@ The _Flow-ID_ must be passed through:
 * RESTful API requests via {X-Flow-ID} proprietary header (see <<184>>)
 * Published events via `flow_id` event field (see <<event-metadata, metadata>>)
 
-It must be an random unique string consisting of maximal 128 chars, restricted
-to the character set `[a-zA-Z0-9/+]` (Base64). 
+The following formats are allowed:
+
+* `UUID` ({RFC-4122}[RFC-4122])
+* `Base64` ({RFC-4648}[RFC-4648])
+* `Base64` with URL ({RFC-4648}#section-5[RFC-4648 Section 5])
+* Random unique string restricted to the character set `[a-zA-Z0-9/+_-=]` maximal of 128 characters.
 
 *Note:* If a legacy subsystem can only process _Flow-IDs_ with a specific
 format or length, it must define this restrictions in its API specification,

--- a/chapters/proprietary-headers.adoc
+++ b/chapters/proprietary-headers.adoc
@@ -150,8 +150,8 @@ The _Flow-ID_ must be passed through:
 The following formats are allowed:
 
 * `UUID` ({RFC-4122}[RFC-4122])
-* `Base64` ({RFC-4648}[RFC-4648])
-* `Base64` with URL ({RFC-4648}#section-5[RFC-4648 Section 5])
+* `base64` ({RFC-4648}[RFC-4648])
+* `base64url` ({RFC-4648}#section-5[RFC-4648 Section 5])
 * Random unique string restricted to the character set `[a-zA-Z0-9/+_-=]` maximal of 128 characters.
 
 *Note:* If a legacy subsystem can only process _Flow-IDs_ with a specific

--- a/chapters/references.adoc
+++ b/chapters/references.adoc
@@ -30,6 +30,7 @@ This section collects links to documents to which we refer, and base our guideli
 * *{RFC-7240}[RFC 7240]:* Prefer Header for HTTP
 * *{RFC-7396}[RFC 7396]:* JSON Merge Patch
 * *{RFC-7807}[RFC 7807]:* Problem Details for HTTP APIs
+* *{RFC-4648}[RFC 4648]:* The Base16, Base32, and Base64 Data Encodings
 
 * *{ISO-8601}[ISO 8601]:* Date and time format
 * *{ISO-3166-1-a2}[ISO 3166-1 alpha-2]:* Two letter country codes

--- a/index.adoc
+++ b/index.adoc
@@ -19,6 +19,7 @@
 :RFC-3986: https://tools.ietf.org/html/rfc3986
 :RFC-4122: https://tools.ietf.org/html/rfc4122
 :RFC-4627: https://tools.ietf.org/html/rfc4627
+:RFC-4648: https://tools.ietf.org/html/rfc4648
 :RFC-5322: https://tools.ietf.org/html/rfc5322
 :RFC-6570: https://tools.ietf.org/html/rfc6570
 :RFC-6585: https://tools.ietf.org/html/rfc6585
@@ -37,7 +38,6 @@
 :RFC-7493: https://tools.ietf.org/html/rfc7493
 :RFC-7807: https://tools.ietf.org/html/rfc7807
 :RFC-8288: https://tools.ietf.org/html/rfc8288
-:RFC-4648: https://tools.ietf.org/html/rfc4648
 
 :link-relations: http://www.iana.org/assignments/link-relations
 

--- a/index.adoc
+++ b/index.adoc
@@ -37,6 +37,7 @@
 :RFC-7493: https://tools.ietf.org/html/rfc7493
 :RFC-7807: https://tools.ietf.org/html/rfc7807
 :RFC-8288: https://tools.ietf.org/html/rfc8288
+:RFC-4648: https://tools.ietf.org/html/rfc4648
 
 :link-relations: http://www.iana.org/assignments/link-relations
 


### PR DESCRIPTION
Fixes #549 
* Add different formats support for `Flow-ID` such as `UUID`, `Base 64` and `Base 64` with URL.
* Add link to Base64 RFC

I keep regular expression as `[a-zA-Z0-9/+_-=]` and did not replace `[A-Za-z0-9_]` with `\w` because of readability (no need to check every time what is `\w` actually means). If majority thinks that `\w` is better I am fine to replace it.