### PR TITLE
fix: generic fields example in common-data-types

### DIFF
--- a/chapters/common-data-types.adoc
+++ b/chapters/common-data-types.adoc
@@ -154,8 +154,8 @@ tree_node:
       type: string
   example:
     id: '123435'
-    created: '2017-04-12T23:20:50.52Z'
-    modified: '2017-04-12T23:20:50.52Z'
+    created_at: '2017-04-12T23:20:50.52Z'
+    modified_at: '2017-04-12T23:20:50.52Z'
     type: 'LEAF'
     parent_node_id: '534321'
 ----


### PR DESCRIPTION
The fields in the example (`created`, `modified`) did not match the defined `properties` (`created_at`, `modified_at`).