### PR TITLE
Extend DELETE request description

### DIFF
--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -185,8 +185,9 @@ options.
 {DELETE} requests are used to *delete* resources. The semantic is best
 described as _"please delete the resource identified by the URL"_.
 
-* {DELETE} requests are usually applied to single resources, not on collection
-resources, as this would imply deleting the entire collection
+* {DELETE} requests are usually applied to single resource but not on collection resources, as this would imply
+deleting the entire collection. 
+* {DELETE} request can be applied to multiple resources using query parameters (<<delete-with-query-params>>).
 * successful {DELETE} requests will usually generate {200} (if the deleted
 resource is returned) or {204} (if no content is returned)
 * failed {DELETE} requests will usually generate {404} (if the resource cannot
@@ -198,6 +199,44 @@ depending on how the resource is represented after deletion. Under no
 circumstances the resource must be accessible after this operation on its
 endpoint.
 
+[[delete-with-query-params]]
+=== DELETE with query parameters
+
+{DELETE} request can have query parameters. Query parameters should be used as filter parameters on a resource and not 
+for passing context information to steer method behaviour.
+
+==== Example
+[source, http]
+----
+DELETE /resources?param1=value1&param2=value2...&paramN=valueN
+----
+
+Some resources may be partially deleted by {DELETE} request with query parameters due to errors or business logic issues. 
+It is recommended that API designer explicitly states the behaviour of the {DELETE} operation with query parameters.
+
+The response status code of the {DELETE} method with query parameters request should match semantics of usual 
+{DELETE} requests. In some situtuations API may return {207} response with a payload describing operation 
+results (see <<152>> for details).
+
+[[delete-with-body]]
+=== DELETE with body
+
+In some situations a {DELETE} of a sigle resource requires additional information to perform an operation. As {RFC-7231}#section-4.3.5[RFC-7231] states,
+a payload in the {DELETE} request has undefined semantics. In such situations the {DELETE} can be replaced by a {POST} 
+request with the payload. The {POST} request should have a `resource-id` path parameter.
+`DELETE` with body response code behavior the same as for usual {DELETE} request.
+
+==== Example
+[source, http]
+----
+POST /resources/{resource-id}
+
+{
+  "key1": "Value 1",
+  ...
+  "keyN": "Value N",
+}
+----
 
 [[head]]
 === HEAD

--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -51,7 +51,7 @@ the URL. Request headers are reserved for general context information (see
 reliable and depend on clients, gateways, server, and actual settings. Thus,
 switching to headers does not solve the original problem.
 
-*Hint:* As {GET-with-body} is used to transport extensive query parameters,
+*Hint:* As {GET-with-Body} is used to transport extensive query parameters,
 the {cursor} cannot any longer be used to encode the query filters in case of
 <<160, cursor-based pagination>>. As a consequence, it is best practice to
 transport the query filters in the body, while using <<161, pagination links>>
@@ -185,13 +185,14 @@ options.
 {DELETE} requests are used to *delete* resources. The semantic is best
 described as _"please delete the resource identified by the URL"_.
 
-* {DELETE} requests are usually applied to single resource but not on collection resources, as this would imply
-deleting the entire collection. 
-* {DELETE} request can be applied to multiple resources using query parameters (<<delete-with-query-params>>).
+* {DELETE} requests are usually applied to single resources, not on
+  collection resources, as this would imply deleting the entire collection.
+* {DELETE} request can be applied to multiple resources at once using query
+  parameters on the collection resource (see <<delete-with-query-params>>).
 * successful {DELETE} requests will usually generate {200} (if the deleted
-resource is returned) or {204} (if no content is returned)
+  resource is returned) or {204} (if no content is returned).
 * failed {DELETE} requests will usually generate {404} (if the resource cannot
-be found) or {410} (if the resource was already deleted before)
+  be found) or {410} (if the resource was already deleted before).
 
 *Important:* After deleting a resource with {DELETE}, a {GET} request on the
 resource is expected to either return {404} (not found) or {410} (gone)
@@ -199,42 +200,50 @@ depending on how the resource is represented after deletion. Under no
 circumstances the resource must be accessible after this operation on its
 endpoint.
 
+
 [[delete-with-query-params]]
 === DELETE with query parameters
 
-{DELETE} request can have query parameters. Query parameters should be used as filter parameters on a resource and not 
-for passing context information to steer method behaviour.
+{DELETE} request can have query parameters. Query parameters should be used as
+filter parameters on a resource and not for passing context information to
+control the operation behavior.
 
-==== Example
 [source, http]
 ----
 DELETE /resources?param1=value1&param2=value2...&paramN=valueN
 ----
 
-Some resources may be partially deleted by {DELETE} request with query parameters due to errors or business logic issues. 
-It is recommended that API designer explicitly states the behaviour of the {DELETE} operation with query parameters.
+**Note:** When providing {DELETE} with query parameters, API designers must
+carefully document the behavior in case of (partial) failures to manage client
+expectations properly.
 
-The response status code of the {DELETE} method with query parameters request should match semantics of usual 
-{DELETE} requests. In some situtuations API may return {207} response with a payload describing operation 
-results (see <<152>> for details).
+The response status code of {DELETE} with query parameters requests should be
+similar to usual {DELETE} requests. In addition, it may return the status code
+{207} using a payload describing the operation results (see <<152>> for
+details).
+
 
 [[delete-with-body]]
 === DELETE with body
 
-In some situations a {DELETE} of a sigle resource requires additional information to perform an operation. As {RFC-7231}#section-4.3.5[RFC-7231] states,
-a payload in the {DELETE} request has undefined semantics. In such situations the {DELETE} can be replaced by a {POST} 
-request with the payload. The {POST} request should have a `resource-id` path parameter.
-`DELETE` with body response code behavior the same as for usual {DELETE} request.
+In rare cases {DELETE} may require additional information, that cannot be
+classified as filter parameters and thus should be transported via payload, to
+perform the operation. Since {RFC-7231}#section-4.3.5[RFC-7231] states, that
+{DELETE} has an undefined semantic for payloads, we recommend to utilize {POST}
+in this cases similar to {GET-with-Body}.
 
-==== Example
+In this case the endpoint must be documented with the hint {DELETE-with-Body}
+to transport the {DELETE} semantic of this call. The response status code of
+{DELETE-with-Body} requests should be similar to usual {DELETE} requests.
+
 [source, http]
 ----
 POST /resources/{resource-id}
 
 {
-  "key1": "Value 1",
+  "prop1": "value1",
   ...
-  "keyN": "Value N",
+  "propN": "valueN",
 }
 ----
 

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -96,7 +96,7 @@ No content - There is no response body.
 |[[status-code-207]]{207}|
 Multi-Status - The response body contains multiple status informations for
 different parts of a batch/bulk request (see <<152>>).
-|{POST}
+|{POST}, ({DELETE})
 |=======================================================================
 
 

--- a/index.adoc
+++ b/index.adoc
@@ -70,11 +70,12 @@
 // Attributes to improve Design and linking of HTTP methods.
 // Do not use in titles!! This is breaking references in asciidoctor - may be bug.
 :GET: pass:[<a href="#get"><code>GET</code></a>]
-:GET-with-Body: pass:[<a href="#get-with-body"><code>GET With Body</code></a>]
+:GET-with-Body: pass:[<a href="#get-with-body"><code>GET with body</code></a>]
 :PUT: pass:[<a href="#put"><code>PUT</code></a>]
 :POST: pass:[<a href="#post"><code>POST</code></a>]
 :PATCH: pass:[<a href="#patch"><code>PATCH</code></a>]
 :DELETE: pass:[<a href="#delete"><code>DELETE</code></a>]
+:DELETE-with-Body: pass:[<a href="#delete-with-body"><code>DELETE with body</code></a>]
 :HEAD: pass:[<a href="#head"><code>HEAD</code></a>]
 :OPTIONS: pass:[<a href="#options"><code>OPTIONS</code></a>]
 :TRACE: pass:[<a href="#trace"><code>TRACE</code></a>]


### PR DESCRIPTION
Extend DELETE request description with following options:

* Add `DELETE` with query parameters operation
* Add `DELETE` with body operation

Fixes: #573