### PR TITLE
fix: image and table of contents (#602)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ clean:
 
 pull:
 	docker pull $(DOCKER);
-	mkdir -p $(DIRBUILDS);
 
 check: check-rules
 check-rules: check-rules-duplicates check-rules-incorrects
@@ -40,7 +39,8 @@ next-rule-id:
 	echo $$(($$(echo $${RULE_IDS[0]} | tr -d '\[' | tr -d '\]' | tr -d '#') + 1));
 
 assets:
-	cp -r assets $(DIRBUILDS);
+	mkdir -p $(DIRBUILDS);
+	cp -r assets $(DIRBUILDS)/assets;
 	cp -r models/* $(DIRBUILDS);
 	cp -r -n legacy/* $(DIRBUILDS);
 

--- a/chapters/hyper-media.adoc
+++ b/chapters/hyper-media.adoc
@@ -158,8 +158,7 @@ cognitive overhead. It consists of a simple URI value in combination with the
 corresponding {link-relations}[link relations], e.g. {next}, {prev}, {first},
 {last}, or {self}.
 
-See <<simple-hypertext-control-fields>> and <<161>> for examples and more
-information.
+See <<164>> and <<161>> for more information and examples.
 
 
 [#166]

--- a/index.adoc
+++ b/index.adoc
@@ -211,9 +211,9 @@ image::assets/api-zalando-small.jpg[API Guild Logo]
 
 Other formats: link:zalando-guidelines.pdf[PDF], link:zalando-guidelines.epub[EPUB3]
 
-ifndef::ebook-format
+ifndef::ebook-format[]
 toc::[]
-endif::ebook-format
+endif::ebook-format[]
 
 :sectnums:
 


### PR DESCRIPTION
fixes #602.

This fix re-enters the table of content and the image lost during #597. In addition, it substitutes a broken link now visible in log against the assumed original target.