### PR TITLE
clarify the UPPER_SNAKE_CASE rule for enums (#527)

### DIFF
--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -26,10 +26,17 @@ Others, like Google and Amazon, use both - but not only camelCase. It’s
 essential to establish a consistent look and feel such that JSON looks
 as if it came from the same hand.
 
+[#125]
+== {SHOULD} represent enumerations as strings
+
+Strings are a reasonable target for values that are by design enumerations.
+
 [#240]
-== {MUST} declare enum values using UPPER_SNAKE_CASE format
+== {SHOULD} declare enum values using UPPER_SNAKE_CASE format
 
 Enum values (using `enum` or {x-extensible-enum}) need to consistently use the upper-snake case format, e.g. `VALUE` or `YET_ANOTHER_VALUE`. This approach allows to clearly distinguish values from properties or other elements.
+
+This does not apply where the actual exact values are coming from some outside source, e.g. for language codes from {ISO-639-1}[ISO 639-1], or when declaring possible values for a #137[`sort` parameter].
 
 [#216]
 == {SHOULD} define maps using `additionalProperties`
@@ -156,12 +163,6 @@ ignored, i.e. not modified.
 == {SHOULD} not use `null` for empty arrays
 
 Empty array values can unambiguously be represented as the empty list, `[]`.
-
-
-[#125]
-== {SHOULD} represent enumerations as strings
-
-Strings are a reasonable target for values that are by design enumerations.
 
 
 [#235]

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -36,7 +36,7 @@ Strings are a reasonable target for values that are by design enumerations.
 
 Enum values (using `enum` or {x-extensible-enum}) need to consistently use the upper-snake case format, e.g. `VALUE` or `YET_ANOTHER_VALUE`. This approach allows to clearly distinguish values from properties or other elements.
 
-This does not apply where the actual exact values are coming from some outside source, e.g. for language codes from {ISO-639-1}[ISO 639-1], or when declaring possible values for a #137[`sort` parameter].
+**Note:** This does not apply where the actual exact values are coming from some outside source, e.g. for language codes from {ISO-639-1}[ISO 639-1], or when declaring possible values for a #137[`sort` parameter].
 
 [#216]
 == {SHOULD} define maps using `additionalProperties`


### PR DESCRIPTION
* move rules 125 and 240 together (as they both are about enums)
* MUST → SHOULD for 240
* explain where the rule doesn't apply.