### PR TITLE
Functional naming exception for legacy hostnames

### DIFF
--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -872,13 +872,15 @@ conform to the functional naming depending on the <<219, audience>> as follows:
 ----
 <event-type-name>       ::= <functional-event-name> | <application-event-name>
 
-<functional-event-name> ::= <functional-name>.<event-name>
+<functional-event-name> ::= <functional-name>.<event-name>[.<version>]
 
 <event-name>            ::= [a-z][a-z0-9-]* -- free event name (functional name)
+
+<version>               ::= V[0-9.]* -- major version of non compatible schemas
 ----
 
-The following application specific legacy convention is *only* allowed for
-<<223, internal>> event type names:
+*Hint:* The following convention (e.g. used by legacy STUPS infrastructure) is deprecated 
+and *only* allowed for <<223, internal>> event type names:
 
 [source,bnf]
 ----

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -12,10 +12,20 @@ information about the addressed component. Besides, the most important aspect
 is, that it allows to keep APIs stable in the case of technical and
 organizational changes (Zalando for example maintains an internal naming convention).
 
-To make use of this advantages for APIs with a larger <<219, audience>> we
-strongly recommended to follow the functional naming schema for <<224,
-hostnames>>, <<215, permission names>>, and <<213, event names>> in APIs as
-follows:
+A unique `functional-name` is assigned to each functional component serving an API. 
+It is built of the domain name of the functional group the component is belonging 
+to and a unique a short identifier for the functional component itself:
+
+[source,bnf]
+----
+<functional-name>      ::= <functional-domain>-<functional-component>
+<functional-domain>    ::= [a-z][a-z0-9-]* -- managed functional group of components
+<functional-component> ::= [a-z][a-z0-9-]* -- name of API owning functional component
+----
+
+Depending on the <<219, API audience>>, you *must/should/may* follow the functional 
+naming schema for <<224, hostnames>> and <<213, event names>> 
+(and also <<225, permission names>>, in future) as follows:
 
 [cols="25%,75%,options="header"]
 |=========================================================
@@ -25,30 +35,21 @@ follows:
 | *may*    | component-internal
 |=========================================================
 
-To conduct the functional naming schema, a unique `functional-name` is assigned
-to each functional component. It is built of the domain name of the functional
-group the component is belonging to and a unique a short identifier for the
-functional component itself:
+Please see the following rules for detailed functional naming patterns:
+* <<224>>
+* <<213>>
+// * <<225>>
 
-[source,bnf]
-----
-<functional-name>       ::= <functional-domain>-<functional-component>
-<functional-domain>     ::= [a-z][a-z0-9]*  -- managed functional group of components
-<functional-component>  ::= [a-z][a-z0-9-]* -- name of owning functional component
-----
 
-*Internal Hint*:  Use the simple 
+*Internal Guideance*:  You _must_ use the simple 
 https://github.bus.zalan.do/team-architecture/functional-component-registry[functional
 name registry (internal link)] to register your functional name before using
 it. The registry is a centralized infrastructure service to ensure uniqueness
-of your functional names (and available domains) and to support hostname DNS
-resolution.
-
-Please see the following rules for detailed functional naming patterns:
-
-* <<224>>
-// * <<225>>
-* <<213>>
+of your functional names (and available domains -- including subdomains) and 
+to support hostname DNS resolution. +
+_Hint:_ Due to lexicalic restrictions of DNS names there is no specific separator 
+to split a functional name into (sub) domain and component; this knowledge is only 
+managed in the registry.
 
 
 [#224]
@@ -65,8 +66,8 @@ depending on the <<219, audience>> as follows (see <<223>> for details and
 <functional-hostname>  ::= <functional-name>.zalandoapis.com
 -----
 
-The following application specific legacy convention is *only* allowed for
-hostnames of <<219, component-internal>> APIs:
+*Hint:* The following convention (e.g. used by legacy STUPS infrastructure) is deprecated 
+and *only* allowed for hostnames of <<219, component-internal>> APIs:
 
 [source,bnf]
 -----
@@ -74,6 +75,11 @@ hostnames of <<219, component-internal>> APIs:
 <application-id>       ::= [a-z][a-z0-9-]*  -- application identifier
 <organization-id>      ::= [a-z][a-z0-9-]*  -- organization unit identifier, e.g. team identifier
 -----
+
+*Exception:* There are legacy hostnames used for APIs with `external-partner` audience 
+which may not follow this rule due to backward compatibility constraints. 
+The API Linter maintains a whitelist for this exceptions (including e.g. 
+`api.merchants.zalando.com` and `api-sandbox.merchants.zalando.com`).
 
 
 [#129]

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -119,7 +119,7 @@ standard header so to say implicitly defined via the security section.
 [#225]
 == {MUST} follow naming convention for permissions (scopes)
 
-As long as the <<223,functional naming>> is not supported for permissions,
+As long as the <<223,functional naming>> is not yet supported by our permission registry,
 permission names in APIs must conform to the following naming pattern:
 
 [source,bnf]


### PR DESCRIPTION
fixes https://github.com/zalando/restful-api-guidelines/issues/593

Also adding support for `-` in functional domain names.