### PR TITLE
fix(models): use correct format for type and instance in problem.json

### DIFF
--- a/models/problem-1.0.1.yaml
+++ b/models/problem-1.0.1.yaml
@@ -3,19 +3,18 @@ Problem:
   properties:
     type:
       type: string
-      format: uri
+      format: uri-reference
       description: >
-        A relative URI reference that uniquely identifies the problem type
-        only in the context of the provided API. Opposed to the specification
-        in RFC-7807, it is neither recommended to be dereferencable and point
-        to a human-readable documentation nor globally unique for the problem
-        type.
+        A URI reference that uniquely identifies the problem type only in the
+        context of the provided API. Opposed to the specification in RFC-7807,
+        it is neither recommended to be dereferencable and point to a
+        human-readable documentation nor globally unique for the problem type.
       default: 'about:blank'
       example: '/problem/connection-error'
     title:
       type: string
       description: >
-        A short, summary of the problem type. Written in english and readable
+        A short summary of the problem type. Written in English and readable
         for engineers, usually not suited for non technical stakeholders and
         not localized.
       example: Service Unavailable
@@ -34,15 +33,14 @@ Problem:
       description: >
         A human readable explanation specific to this occurrence of the
         problem that is helpful to locate the problem and give advice on how
-        to proceed. Written in english and readable for engineers, usually not
+        to proceed. Written in English and readable for engineers, usually not
         suited for non technical stakeholders and not localized.
       example: Connection to database timed out
     instance:
       type: string
-      format: uri
+      format: uri-reference
       description: >
-        An relative URI reference that identifies the specific occurrence of
-        the problem, e.g. by adding a fragment identifier or sub-path to the
-        problem type. May be used to locate the root of this problem in the
-        source code.
+        A URI reference that identifies the specific occurrence of the problem,
+        e.g. by adding a fragment identifier or sub-path to the problem type.
+        May be used to locate the root of this problem in the source code.
       example: '/problem/connection-error#token-info-read-timed-out'


### PR DESCRIPTION
This PR includes the following:
    
- According to their descriptions, `type` and `instance` fields
are relative URI or URI references. According to RFC 3986, the formats
should be specified as `uri-reference` instead of `uri`:
    
    https://tools.ietf.org/html/rfc3986#section-4.1
    
    Otherwise, linter tools such as spectral (https://github.com/stoplightio/spectral)
    would fail to lint these models correctly.
    
    The PR adapts these fields accordingly.
    
    As suggested by the community, keeps the file version at 1.0.1.
    
- Also includes minor language fixes to the file.