### PR TITLE
update link to 'The Deprecation HTTP Header' internet draft

### DIFF
--- a/chapters/deprecation.adoc
+++ b/chapters/deprecation.adoc
@@ -61,7 +61,7 @@ breaking effects on ongoing consumers. See also <<193>>.
 == {SHOULD} add `Deprecation` and `Sunset` header to responses
 
 During the deprecation phase, the producer should add a `Deprecation: <date-time>`
-(see https://tools.ietf.org/html/draft-dalal-deprecation-header[draft: RFC
+(see https://tools.ietf.org/html/draft-ietf-httpapi-deprecation-header[draft: RFC
 Deprecation HTTP Header]) and - if also planned - a `Sunset: <date-time>` (see
 {RFC-8594}#section-3[RFC 8594]) header on each response affected by a
 deprecated element (see <<187>>).

--- a/index.adoc
+++ b/index.adoc
@@ -190,7 +190,7 @@
 :Preference-Applied: pass:[<a href="https://tools.ietf.org/html/rfc7240#section-3"><code>Preference-Applied</code></a>]
 
 :Sunset: pass:[<a href="https://tools.ietf.org/html/rfc8594"><code>Sunset</code></a>]
-:Deprecation: pass:[<a href="https://tools.ietf.org/html/draft-dalal-deprecation-header"><code>Deprecation</code></a>]
+:Deprecation: pass:[<a href="https://tools.ietf.org/html/draft-ietf-httpapi-deprecation-header"><code>Deprecation</code></a>]
 
 :Retry-After: pass:[<a href="https://tools.ietf.org/html/rfc7231#section-7.1.3"><code>Retry-After</code></a>]
 :Vary: pass:[<a href="https://tools.ietf.org/html/rfc7231#section-7.1.4"><code>Vary</code></a>]


### PR DESCRIPTION
The internet draft 'draft-dalal-deprecation-header' is superseded by
'draft-ietf-httpapi-deprecation-header'.