### PR TITLE
feat: improve cursor based pagination guideline (#587)

### DIFF
--- a/chapters/best-practices.adoc
+++ b/chapters/best-practices.adoc
@@ -7,6 +7,107 @@ guidelines, but should provide guidance for common challenges we face when
 implementing RESTful APIs.
 
 
+[[cursor-based-pagination]]
+== Cursor-based pagination in RESTful APIs
+
+Cursor-based pagination is a very powerful and valuable technique (see also
+<<160>>, that allows to efficiently provide a stable view on changing data.
+This is obtained by using an anchor element that allows to retrieve all page
+elements directly via an ordering combined-index, usually based on `created_at`
+or `modified_at`. Simple said, the cursor is the information set needed to
+reconstruct the database query to retrieves the minimal page information from
+the data storage.
+
+The {cursor} itself is an opaque string, transmitted forth and back between
+service and clients, that must never be *inspected* or *constructed* by
+clients. Therefore, it is good practice to encode (encrypt) its content in a
+none-human-readable form.
+
+The {cursor} content usually consists of a pointer to the anchor element
+defining the page position in the collection, a flag whether the element is
+included or excluded into/from the page, the retrieval direction, and a hash
+over the applied query filters (or the query filter itself) to safely re-create
+the collection. It is important to note, that a {cursor} should be always
+defined in relation to the current page to anticipate all occurring changes
+when progressing.
+
+The {cursor} is usually defined as follows:
+
+[source,yaml]
+----
+Cursor:
+  descriptions: >
+    Cursor structure that contains all necessary information to efficiently
+    retrieve a page from the data store.
+  type: object
+  properties:
+    position:
+      description: >
+        Object containing the keys pointing to the anchor element that is
+        defining the collection resource page. Normally the position is given
+        by the first or the last page element. The position object contains all
+        values required to access the element efficiently via the ordered,
+        combined index, e.g `modified_at`, `id`.
+      type: object
+      properties: ...
+
+    element:
+      description: >
+        Flag whether the anchor element, which is pointed to by the `position`,
+        should be *included* or *excluded* from the result set. Normally, only
+        the current page includes the pointed to element, while all others are
+        exclude it.
+      type: string
+      enum: [ INCLUDED, EXCLUDED ]
+
+    direction:
+      description: >
+        Flag for the retrieval direction that is defining which elements to
+        choose from the collection resource starting from the anchor elements
+        position. It is either *ascending* or *descending* based on the
+        ordering combined index.
+      type: string
+      enum: [ ASCENDING, DESCENDING ]
+
+    query_hash:
+      description: >
+        Stable hash calculated over all query filters applied to create the
+        collection resource that is represented by this cursor.
+      type: string
+
+    query:
+      description: >
+        Object containing all query filters applied to create the collection
+        resource that is represented by this cursor.
+      type: object
+      properties: ...
+
+  required:
+    - position
+    - element
+    - direction
+----
+
+*Note:* In case of complex and long search requests, e.g. when {GET-with-body}
+is required, the {cursor} may not be able to encode the `query`. In this case
+the `query` filters should be transported via body - in the request as well as
+in the response, while the pagination consistency should be ensured via the
+`query_hash`.
+
+*Remark:* It is also important to check the efficiency of the data-access.
+You need to make sure that you have a fully ordered stable index, that allows
+to efficiently resolve all elements of a page. If necessary, you need to
+provide a combined index that includes the `id` to ensure the full order and
+additional filter criteria to ensure efficiency.
+
+=== Further reading
+
+* https://dev.twitter.com/rest/public/timelines[Twitter]
+* http://use-the-index-luke.com/no-offset[Use the Index, Luke]
+* https://www.citusdata.com/blog/1872-joe-nelson/409-five-ways-paginate-postgres-basic-exotic[Paging
+  in PostgreSQL]
+
+
 [[optimistic-locking]]
 == Optimistic locking in RESTful APIs
 

--- a/chapters/best-practices.adoc
+++ b/chapters/best-practices.adoc
@@ -89,10 +89,10 @@ Cursor:
 ----
 
 *Note:* In case of complex and long search requests, e.g. when {GET-with-body}
-is required, the {cursor} may not be able to encode the `query`. In this case
-the `query` filters should be transported via body - in the request as well as
-in the response, while the pagination consistency should be ensured via the
-`query_hash`.
+is already required, the {cursor} may not be able to include the `query` because
+of common HTTP parameter size restrictions. In this case the `query` filters
+should be transported via body - in the request as well as in the response,
+while the pagination consistency should be ensured via the `query_hash`.
 
 *Remark:* It is also important to check the efficiency of the data-access.
 You need to make sure that you have a fully ordered stable index, that allows

--- a/chapters/best-practices.adoc
+++ b/chapters/best-practices.adoc
@@ -21,7 +21,7 @@ the data storage.
 The {cursor} itself is an opaque string, transmitted forth and back between
 service and clients, that must never be *inspected* or *constructed* by
 clients. Therefore, it is good practice to encode (encrypt) its content in a
-none-human-readable form.
+non-human-readable form.
 
 The {cursor} content usually consists of a pointer to the anchor element
 defining the page position in the collection, a flag whether the element is
@@ -31,7 +31,7 @@ the collection. It is important to note, that a {cursor} should be always
 defined in relation to the current page to anticipate all occurring changes
 when progressing.
 
-The {cursor} is usually defined as follows:
+The {cursor} is usually defined as an encoding of the following information:
 
 [source,yaml]
 ----

--- a/chapters/common-data-types.adoc
+++ b/chapters/common-data-types.adoc
@@ -172,11 +172,12 @@ resources. There is very little utility for API consumers in having different
 names or value types for these fields across APIs.
 
 
+[[pagination-fields]]
 [[link-relation-fields]]
-=== Link relation fields
+=== Link relation and pagination fields
 
-To foster a consistent look and feel using simple hypertext controls for
-paginating and iterating over collection values the response objects should
+To foster a consistent look and feel using simple hypertext controls or cursors
+for paginating and iterating over collection values the response objects should
 follow a common pattern using the below field semantics:
 
 * [[self]]{self}:the link or cursor in a pagination response or object
@@ -202,47 +203,50 @@ the following field (see also {GET-with-body}):
 * [[query]]{query}: object containing the query filters applied in the search
   request to filter the collection resource.
 
-As Result, the standard response page using <<161, pagination links>> is
-defined as follows:
+As Result, the standard response page using <<160, cursors>> or <<161,
+pagination links>> may be defined as follows:
 
 [source,yaml]
 ----
 ResponsePage:
   type: object
+  required:
+    - items
+    - next
   properties:
     self:
-      description: Pagination link pointing to the current page.
+      description: Pagination link|cursor pointing to the current page.
       type: string
-      format: uri
+      format: uri|cursor
     first:
-      description: Pagination link pointing to the first page.
+      description: Pagination link|cursor pointing to the first page.
       type: string
-      format: uri
+      format: uri|cursor
     prev:
-      description: Pagination link pointing to the previous page.
+      description: Pagination link|cursor pointing to the previous page.
       type: string
-      format: uri
+      format: uri|cursor
     next:
-      description: Pagination link pointing to the next page.
+      description: Pagination link|cursor pointing to the next page.
       type: string
-      format: uri
+      format: uri|cursor
     last:
-      description: Pagination link pointing to the last page.
+      description: Pagination link|cursor pointing to the last page.
       type: string
-      format: uri
+      format: uri|cursor
 
-     query:
-       description: >
-         Object containing the query filters applied to the collection resource.
-       type: object
-       properties: ...
+    query:
+      description: >
+        Object containing the query filters applied to the collection resource.
+      type: object
+      properties: ...
 
-     items:
-       description: Array of collection items.
-       type: array
-       required: false
-       items:
-         type: ...
+    items:
+      description: Array of collection items.
+      type: array
+      required: false
+      items:
+        type: ...
 ----
 
 The response page may contain additional metadata about the collection or the

--- a/chapters/common-data-types.adoc
+++ b/chapters/common-data-types.adoc
@@ -173,12 +173,12 @@ names or value types for these fields across APIs.
 
 
 [[pagination-fields]]
-[[link-relation-fields]]
-=== Link relation and pagination fields
+=== Pagination fields
 
-To foster a consistent look and feel using simple hypertext controls or cursors
-for paginating and iterating over collection values the response objects should
-follow a common pattern using the below field semantics:
+For iterating over collections (result sets) we propose to either use cursors
+(see <<160>>) or simple hypertext controls (see <<161>>). To implement these
+in a consistent way, we have defined a response page object pattern with the
+following field semantics:
 
 * [[self]]{self}:the link or cursor in a pagination response or object
   pointing to the same collection object or page.
@@ -248,6 +248,10 @@ ResponsePage:
       items:
         type: ...
 ----
+
+*Note:* While you may support cursors for {next}, {prev}, {first}, {last}, and
+{self} (see <<pagination-fields>>), it is best practice to replace these with
+links in favor of <<161>>.
 
 The response page may contain additional metadata about the collection or the
 current page.

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -213,7 +213,7 @@ paginating, you must stick to the following naming conventions:
   constructed by clients. It usually (encrypted) encodes the page position,
   i.e. the identifier of the first or last page element, the pagination
   direction, and the applied query filters to recreate the collection. See
-  <<160, pagination>> section below.
+  <<cursor-based-pagination>> or <<pagination>> section below.
 * [[limit]]{limit}: client suggested limit to restrict the number of entries on
   a page. See <<pagination>> section below.
 

--- a/chapters/pagination.adoc
+++ b/chapters/pagination.adoc
@@ -63,22 +63,13 @@ the page position, i.e. the identifier of the first or last page element, the
 pagination direction, and the applied query filters - or a hash over these -
 to safely recreate the collection (see also <<cursor-based-pagination>>).
 
-*Note:* While you may support cursors for {next}, {prev}, {first}, {last}, and
-{self} (see <<pagination-fields>>), it is best practice to replace these with
-links in favor of <<161>>.
-
 
 [#161]
 == {SHOULD} use pagination links where applicable
 
 To simplify client design, APIs should support <<165, simplified hypertext
-controls>> for pagination over collections whenever applicable. Beside {next}
-this may comprise the support for {prev}, {first}, {last}, and {self} as
-{link-relations}[link relations] (see also <<pagination-fields>> for
-details).
-
-The page content is transported via {items}, while the {query} object may
-contain the query filters applied to the collection resource as follows:
+controls>> for paginating over collections whenever applicable as follows (see
+also <<pagination-fields>> for details):
 
 [source,json]
 ----

--- a/chapters/pagination.adoc
+++ b/chapters/pagination.adoc
@@ -61,72 +61,11 @@ The {cursor} used for pagination is an opaque pointer to a page, that must
 never be *inspected* or *constructed* by clients. It usually encodes (encrypts)
 the page position, i.e. the identifier of the first or last page element, the
 pagination direction, and the applied query filters - or a hash over these -
-to safely recreate the collection. The {cursor} may be defined as follows:
+to safely recreate the collection (see also <<cursor-based-pagination>>).
 
-[source,yaml]
-----
-Cursor:
-  type: object
-  properties: 
-    position:
-      description: >
-        Object containing the identifier(s) pointing to the entity that is
-        defining the collection resource page - normally the position is
-        represented by the first or the last page element.
-      type: object
-      properties: ...
-
-    direction:
-      description: >
-        The pagination direction that is defining which elements to choose
-        from the collection resource starting from the page position.
-      type: string
-      enum: [ ASC, DESC ]
-
-    query:
-      description: >
-        Object containing the query filters applied to create the collection
-        resource that is represented by this cursor.
-      type: object
-      properties: ...
-
-    query_hash:
-      description: >
-        Stable hash calculated over all query filters applied to create the
-        collection resource that is represented by this cursor.
-      type: string
-
-  required:
-    - position
-    - direction
-----
-
-The page information for cursor-based pagination should consist of a {cursor}
-set, that besides {next} may provide support for {prev}, {first}, {last}, and
-{self} as follows (see also <<link-relation-fields>>):
-
-[source,json]
-----
-{
-  "cursors": {
-    "self": "...",
-    "first": "...",
-    "prev": "...",
-    "next": "...",
-    "last": "..."
-  },
-  "items": [... ]
-}
-----
-
-*Note:* The support of the {cursor} set may be dropped in favor of <<161>>.
-
-Further reading:
-
-* https://dev.twitter.com/rest/public/timelines[Twitter]
-* http://use-the-index-luke.com/no-offset[Use the Index, Luke]
-* https://www.citusdata.com/blog/1872-joe-nelson/409-five-ways-paginate-postgres-basic-exotic[Paging
-  in PostgreSQL]
+*Note:* While you may support cursors for {next}, {prev}, {first}, {last}, and
+{self} (see <<pagination-fields>>), it is best practice to replace these with
+links in favor of <<161>>.
 
 
 [#161]
@@ -135,7 +74,7 @@ Further reading:
 To simplify client design, APIs should support <<165, simplified hypertext
 controls>> for pagination over collections whenever applicable. Beside {next}
 this may comprise the support for {prev}, {first}, {last}, and {self} as
-{link-relations}[link relations] (see also <<link-relation-fields>> for
+{link-relations}[link relations] (see also <<pagination-fields>> for
 details).
 
 The page content is transported via {items}, while the {query} object may
@@ -156,14 +95,6 @@ contain the query filters applied to the collection resource as follows:
   "items": [...]
 }
 ----
-
-*Note:* In case of complex search requests, e.g. when {GET-with-body} is
-required, the {cursor} may not be able to encode all query filters. In this
-case, it is best practice to encode only page position and direction in the
-{cursor} and transport the query filter in the body - in the request as well
-as in the response. To protect the pagination sequence, in this case it is
-recommended, that the {cursor} contains a hash over all applied query
-filters for pagination request validation.
 
 *Remark:* You should avoid providing a total count unless there is a clear
 need to do so. Very often, there are significant system and performance


### PR DESCRIPTION
fixes #587.

* Moved implementation details of `cursor` to the `Best practices` chapter.
* Increased consistency of terminology and model in `Link relation an pagination fields`.
* Simplified `Should prefer cursor-based pagination` section.

Not sure whether this proposal fully covers the expectations stated in #587.