### PR TITLE
Add Info about the OAuth2 Security Schemes to be used

### DIFF
--- a/chapters/changelog.adoc
+++ b/chapters/changelog.adoc
@@ -34,7 +34,7 @@ To see a list of all changes, please have a look at the https://github.com/zalan
 * `2019-08-29`: new rule <<239>>, extend <<167>> pointing to {RFC-7493}[RFC-7493]
 * `2019-08-29`: new rules <<236>>, <<237>>
 * `2019-07-30`: new rule <<238>>
-* `2019-07-30`: change <<519>> from {SHOULD} to {MUST}
+* `2019-07-30`: change <<173>> from {SHOULD} to {MUST}
 * `2019-07-30`: change "{SHOULD} Null values should have their fields removed to" <<123>>.
 * `2019-07-25`: new rule <<235>>.
 * `2019-07-18`: improved cursor guideline for {GET-with-Body}.

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -41,9 +41,12 @@ security:
   - BearerAuth: [ api-repository.read ]
 ----
 
-*Note:* If you need to support other OAuth2 authorizations flows as defined by
+*Note:* If you need to support specific OAuth2 authorizations flows as defined by
 {RFC-6750}[RFC 6750], please consult the https://swagger.io/docs/specification/authentication/oauth2/[Open
 API OAuth 2.0 Authentication] section for details on how to describe correctly.
+Do not use OAuth flows (e.g. `implicit`) if not directly supported by the service, because
+they make use of redirection and expose authentication server address details. 
+
 
 [#105]
 == {MUST} define and assign permissions (scopes)

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -14,7 +14,7 @@ Most of our services require authentication via a token being passed with the
 https://swagger.io/docs/specification/authentication/bearer-authentication/[bearerAuth security scheme] 
 for HTTP authentication (originally created as part of OAuth 2.0). 
 In situations where the service supports specific OAuth2 flows 
--- see https://tools.ietf.org/html/rfc6750[RFC 6750], like `implicit` with redirection to authorization server --
+-- see {RFC-6750}[RFC 6750], like `implicit` with redirection to authorization server --
 you should use https://swagger.io/docs/specification/authentication/oauth2/[OAuth 2.0 security scheme] 
 exposing flow and authentication server details. 
 

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -5,11 +5,20 @@
 [#104]
 == {MUST} secure endpoints with OAuth 2.0
 
-Every API endpoint needs to be secured using OAuth 2.0. Please refer to the
-https://swagger.io/docs/specification/authentication/[Authentication section] of the official
+Every API endpoint _must_ to be secured using OAuth 2.0. Please refer to the
+https://swagger.io/docs/specification/authentication/[Authentication section] of the 
 Open API specification on how to specify security definitions in your API.
 
-The following code snippet shows how to define the authorization scheme using
+Most of our services require authentication via a token being passed with the 
+`Authorization: Bearer <token>` header, and here you _should_ use the 
+https://swagger.io/docs/specification/authentication/bearer-authentication/[bearerAuth security scheme] 
+for HTTP authentication (originally created as part of OAuth 2.0). 
+In situations where the service supports specific OAuth2 flows 
+-- see https://tools.ietf.org/html/rfc6750[RFC 6750], like `implicit` with redirection to authorization server --
+you should use https://swagger.io/docs/specification/authentication/oauth2/[OAuth 2.0 security scheme] 
+exposing flow and authentication server details. 
+
+*Example*: The following code snippet shows how to define the authorization scheme using
 a bearer token (e.g. JWT token).
 
 [source,yaml]

--- a/index.adoc
+++ b/index.adoc
@@ -26,6 +26,7 @@
 :RFC-6570: https://tools.ietf.org/html/rfc6570
 :RFC-6585: https://tools.ietf.org/html/rfc6585
 :RFC-6648: https://tools.ietf.org/html/rfc6648
+:RFC-6750: https://tools.ietf.org/html/rfc6750
 :RFC-6838: https://tools.ietf.org/html/rfc6838
 :RFC-6901: https://tools.ietf.org/html/rfc6901
 :RFC-6902: https://tools.ietf.org/html/rfc6902


### PR DESCRIPTION
Improved description of security schemas and application in Zalando. Also fixed a change log entry added in #632 with incorrect rule reference.