### PR TITLE
Editorial update of header naming convention

### DIFF
--- a/chapters/common-headers.adoc
+++ b/chapters/common-headers.adoc
@@ -1,9 +1,35 @@
 [[common-headers]]
-= Common headers
+= Standard headers
 
-This section describes a handful of headers, which we found raised the most
+This section describes a handful of standard headers, which we found raising the most
 questions in our daily usage, or which are useful in particular circumstances
 but not widely known.
+
+
+[#133]
+== {MAY} use standardized headers
+
+Use http://en.wikipedia.org/wiki/List_of_HTTP_header_fields[this list] and
+explicitly mention its support in your Open API definition.
+
+
+[#132]
+== {SHOULD} use uppercase separate words with hyphens for HTTP headers
+
+This convention is followed by most standard headers e.g. as defined in 
+{RFC-2616}[RFC 2616] and {RFC-4229}[RFC 4229]. Examples:
+
+[source,http]
+----
+If-Modified-Since
+Accept-Encoding
+Content-ID
+Language
+----
+
+Note, HTTP standard defines headers as case-insensitive ({RFC-7230}#page-22[RFC 7230, p.22]). 
+However, for sake of readability and consistency you should follow the convention when 
+using standard or proprietary headers. Exceptions are common abbreviations like `ID`. 
 
 
 [#178]
@@ -26,13 +52,6 @@ limited to:
 * {Content-Range} is used in responses to range requests to indicate which part
   of the requested resource representation is delivered with the body.
 * {Content-Type} indicates the media type of the body content.
-
-
-[#133]
-== {MAY} use standardized headers
-
-Use http://en.wikipedia.org/wiki/List_of_HTTP_header_fields[this list] and
-mention its support in your Open API definition.
 
 
 [#180]

--- a/chapters/common-headers.adoc
+++ b/chapters/common-headers.adoc
@@ -1,4 +1,5 @@
 [[common-headers]]
+[[standard-headers]]
 = Standard headers
 
 This section describes a handful of standard headers, which we found raising the most

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -97,40 +97,6 @@ parameters. For example `{shipment_order_id}` would be ok as a path
 parameter.
 
 
-[#130]
-== {MUST} use snake_case (never camelCase) for query parameters
-
-Examples:
-
-[source]
-----
-customer_number, order_id, billing_address
-----
-
-
-[#132]
-== {SHOULD} prefer hyphenated-pascal-case for HTTP header fields
-
-This is for consistency in your documentation (most other headers follow
-this convention). Avoid camelCase (without hyphens). Exceptions are
-common abbreviations like "ID."
-
-Examples:
-
-[source,http]
-----
-Accept-Encoding
-Apply-To-Redirect-Ref
-Disposition-Notification-Options
-Original-Message-ID
-----
-
-See also: {RFC-7230}#page-22[HTTP Headers are case-insensitive (RFC 7230)].
-
-See <<common-headers>> and <<proprietary-headers>> sections for more guidance
-on HTTP headers.
-
-
 [#134]
 == {MUST} pluralize resource names
 

--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -97,6 +97,17 @@ parameters. For example `{shipment_order_id}` would be ok as a path
 parameter.
 
 
+[#130]
+== {MUST} use snake_case (never camelCase) for query parameters
+
+Examples:
+
+[source]
+----
+customer_number, order_id, billing_address
+----
+
+
 [#134]
 == {MUST} pluralize resource names
 

--- a/index.adoc
+++ b/index.adoc
@@ -16,10 +16,12 @@
 
 // Some link short cuts.
 :RFC-1034: https://tools.ietf.org/html/rfc1034
+:RFC-2616: https://tools.ietf.org/html/rfc2616
 :RFC-2673: https://tools.ietf.org/html/rfc2673
 :RFC-3339: https://tools.ietf.org/html/rfc3339
 :RFC-3986: https://tools.ietf.org/html/rfc3986
 :RFC-4122: https://tools.ietf.org/html/rfc4122
+:RFC-4229: https://tools.ietf.org/html/rfc4229
 :RFC-4627: https://tools.ietf.org/html/rfc4627
 :RFC-4648: https://tools.ietf.org/html/rfc4648
 :RFC-5322: https://tools.ietf.org/html/rfc5322


### PR DESCRIPTION
https://github.com/zalando/restful-api-guidelines/issues/651

* move header naming convention to Common Headers
* make clearer that first letter upper case writing should be followed (though generic HTTP standard defines headers as case insensitive) 