### PR TITLE
Event received_at / occurred_at definition

### DIFF
--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -468,13 +468,16 @@ EventMetadata:
       type: string
       example: 'example.important-business-event'
     occurred_at:
-      description: When the event was created according to the producer.
+      description: |
+         Timestamp of when the event was created by the producer application. 
+         (Typically, it differs from when the event is posted by the producer and received by Nakadi via the API.)
       type: string
       format: date-time
       example: '1996-12-19T16:39:57-08:00'
     received_at:
       description: |
-        When the event was seen by an intermediary such as a broker.
+        Timestamp of when the event was received by Nakadi via the event post endpoints. 
+        It is automatically enriched, and events will be rejected if set by the Event producer.
       type: string
       readOnly: true
       format: date-time
@@ -610,7 +613,7 @@ jump forward and backward to compensate drifts or leap-seconds. If you use anywa
 timestamps to indicate event ordering, you _must_ carefully ensure that the designated 
 event order is not messed up by these effects and use UTC time zone format.
 
-*Note:* The `occurred_at` and `partition_offset` metadata set by Nakadi typically is 
+*Note:* The `received_at` and `partition_offset` metadata set by Nakadi typically is 
 different from the business event ordering, since (1) Nakadi is a distributed concurrent 
 system without atomic, ordered event creation and (2) the application's implementation
 of event publishing may not exactly reflect the business order. The business ordering 


### PR DESCRIPTION
Updated for more clearness and consistency with Nakadi API definition.
Fixed `occurred_at` --> `received_at` in rule 203.