### PR TITLE
Use Standard Media Types

### DIFF
--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -48,7 +48,7 @@ of Internet Assigned Numbers Authority (IANA)) as `content-type` (or `accept`) h
 information. More specifically, for JSON payload you should use the standard media type 
 `application/json` (or `application/problem+json` for <<176>>).
 
-You should avoid using customer media types like `application/x.zalando.article+json`. 
+You should avoid using custom media types like `application/x.zalando.article+json`. 
 Custom media types beginning with `x` bring no advantage compared to the
 standard media type for JSON, and make automated processing more difficult.
 They are also {RFC-6838}#section-3.4[discouraged by RFC 6838].

--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -27,22 +27,6 @@ As a consequence, a JSON payload must
   names).
 
 
-[#172]
-== {SHOULD} prefer standard media type name `application/json`
-
-Use the standard media type name
-`application/json` (or `application/problem+json` for <<176>>)
-as content type (or accept header) information for JSON payload. 
-
-*Hint:* Previously, this guideline allowed the use of custom media types like 
-`application/x.zalando.article+json`. This usage is not recommended
-anymore and should be avoided, except where it is necessary for cases of
-<<114,media type versioning>>. 
-Custom media types beginning with `x` bring no advantage compared to the
-standard media type for JSON, and make automated processing more difficult.
-They are also {RFC-6838}#section-3.4[discouraged by RFC 6838].
-
-
 [#168]
 == {MAY} pass non-JSON media types using data specific standard formats
 
@@ -53,6 +37,24 @@ format (PDF, DOC, ODF, PPT), or archive format (TAR, ZIP).
 Generic structured data interchange formats other than JSON (e.g. XML, CSV) 
 may be provided, but only additionally to JSON as default format using content negotiation, 
 for specific use cases where clients may not interpret the payload structure.
+
+
+[#172]
+== {SHOULD} use standard media types
+
+You should use standard media types (defined in 
+https://www.iana.org/assignments/media-types/media-types.xhtml[media type registry] 
+of Internet Assigned Numbers Authority (IANA)) as `content-type` (or `accept`) header 
+information. More specifically, for JSON payload you should use the standard media type 
+`application/json` (or `application/problem+json` for <<176>>).
+
+You should avoid using customer media types like `application/x.zalando.article+json`. 
+Custom media types beginning with `x` bring no advantage compared to the
+standard media type for JSON, and make automated processing more difficult.
+They are also {RFC-6838}#section-3.4[discouraged by RFC 6838].
+
+*Exception:* Custom media type should be only used in situations where you need to provide 
+<<114, API endpoint versioning>> (with content negotiation) due to incompatible changes.   
 
 
 [#239]

--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -51,7 +51,6 @@ information. More specifically, for JSON payload you should use the standard med
 You should avoid using custom media types like `application/x.zalando.article+json`. 
 Custom media types beginning with `x` bring no advantage compared to the
 standard media type for JSON, and make automated processing more difficult.
-They are also {RFC-6838}#section-3.4[discouraged by RFC 6838].
 
 *Exception:* Custom media type should be only used in situations where you need to provide 
 <<114, API endpoint versioning>> (with content negotiation) due to incompatible changes.   

--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -42,8 +42,7 @@ for specific use cases where clients may not interpret the payload structure.
 [#172]
 == {SHOULD} use standard media types
 
-You should use standard media types (defined in 
-https://www.iana.org/assignments/media-types/media-types.xhtml[media type registry] 
+You should use standard media types (defined in {media-types}[media type registry] 
 of Internet Assigned Numbers Authority (IANA)) as `content-type` (or `accept`) header 
 information. More specifically, for JSON payload you should use the standard media type 
 `application/json` (or `application/problem+json` for <<176>>).

--- a/index.adoc
+++ b/index.adoc
@@ -29,7 +29,6 @@
 :RFC-6585: https://tools.ietf.org/html/rfc6585
 :RFC-6648: https://tools.ietf.org/html/rfc6648
 :RFC-6750: https://tools.ietf.org/html/rfc6750
-:RFC-6838: https://tools.ietf.org/html/rfc6838
 :RFC-6901: https://tools.ietf.org/html/rfc6901
 :RFC-6902: https://tools.ietf.org/html/rfc6902
 :RFC-7159: https://tools.ietf.org/html/rfc7159

--- a/index.adoc
+++ b/index.adoc
@@ -45,6 +45,7 @@
 :RFC-8594: https://tools.ietf.org/html/rfc8594
 
 :link-relations: http://www.iana.org/assignments/link-relations
+:media-types: https://www.iana.org/assignments/media-types/media-types.xhtml
 
 :BCP47: https://tools.ietf.org/html/bcp47
 :ECMA-262: http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf


### PR DESCRIPTION
Editorial update of rule https://opensource.zalando.com/restful-api-guidelines/#172
to make clearer that it is about usage of standard media types -- with application/json as an important example.