### PR TITLE
fix: resource locations (638)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash 
 DOCKER := asciidoctor/docker-asciidoctor:latest
 DIRMOUNTS := /documents
 DIRCONTENTS := chapters
@@ -5,12 +6,20 @@ DIRSCRIPTS := scripts
 DIRBUILDS := output
 DIRWORK := $(shell pwd -P)
 
-.PHONY: all clean pull check assets
-.PHONY: rules html pdf epub force
+.PHONY: all clean install lint format pull assets rules html pdf epub force
+.PHONY: check check-rules check-rules-duplicates check-rules-incorrects
+.PHONY: next-rule-id
 
 all: clean html pdf epub rules
 clean:
 	rm -rf $(DIRBUILDS);
+
+install:
+	npm install -g markdownlint-cli;
+lint:
+	markdownlint --config linter.yaml chapters/*.adoc;
+format:
+	markdownlint --config linter.yaml --fix chapters/*.adoc;
 
 pull:
 	docker pull $(DOCKER);
@@ -41,7 +50,8 @@ next-rule-id:
 assets:
 	mkdir -p $(DIRBUILDS);
 	cp -r assets $(DIRBUILDS)/assets;
-	cp -r models/* $(DIRBUILDS);
+	cp -r models $(DIRBUILDS)/models;
+	cp -r models/{problem-1.0.{0,1},money-1.0.0}.yaml $(DIRBUILDS);
 	cp -r -n legacy/* $(DIRBUILDS);
 
 rules: check-rules

--- a/chapters/common-data-types.adoc
+++ b/chapters/common-data-types.adoc
@@ -26,7 +26,7 @@ APIs are encouraged to include a reference to the global schema for Money.
 SalesOrder:
   properties:
     grand_total:
-      $ref: 'https://opensource.zalando.com/restful-api-guidelines/money-1.0.0.yaml#/Money'
+      $ref: 'https://opensource.zalando.com/restful-api-guidelines/models/money-1.0.0.yaml#/Money'
 ----
 
 Please note that APIs have to treat Money as a closed data type, i.e. it's not meant to be used in an inheritance hierarchy. That means the following usage is not allowed:

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -31,7 +31,7 @@ responses:
     content:
       "application/problem+json":
         schema:
-          $ref: 'https://opensource.zalando.com/restful-api-guidelines/problem-1.0.1.yaml#/Problem'
+          $ref: 'https://opensource.zalando.com/restful-api-guidelines/models/problem-1.0.1.yaml#/Problem'
 ----
 
 API designers should also think about a **troubleshooting board** as part of
@@ -361,7 +361,7 @@ include `application/problem+json` in the {Accept}-Header to trigger delivery
 of the extended failure information.
 
 The OpenAPI schema definition of the Problem JSON object can be found
-https://opensource.zalando.com/restful-api-guidelines/problem-1.0.1.yaml[on
+https://opensource.zalando.com/restful-api-guidelines/models/problem-1.0.1.yaml[on
 GitHub]. You can reference it by using:
 
 [source,yaml]
@@ -372,7 +372,7 @@ responses:
     content:
       "application/problem+json":
         schema:
-          $ref: 'https://opensource.zalando.com/restful-api-guidelines/problem-1.0.1.yaml#/Problem'
+          $ref: 'https://opensource.zalando.com/restful-api-guidelines/models/problem-1.0.1.yaml#/Problem'
 ----
 
 You may define custom problem types as extensions of the Problem JSON object
@@ -399,7 +399,7 @@ identifiers in `type` and `instance` fields:
 
 *Hint:* The use of https://tools.ietf.org/html/rfc3986#section-4.3[absolute
 URIs] is not forbidden but strongly discouraged. If you use absolute URIs,
-please reference https://opensource.zalando.com/restful-api-guidelines/problem-1.0.0.yaml#/Problem[problem-1.0.0.yaml#/Problem] instead.
+please reference https://opensource.zalando.com/restful-api-guidelines/models/problem-1.0.0.yaml#/Problem[problem-1.0.0.yaml#/Problem] instead.
 
 
 [#177]


### PR DESCRIPTION
fixes #638.

I should have done this a long time ago, but now https://github.com/zalando/zally/pull/1259 has broken Zally for incorrectly linked resources, so we have to act quickly and change the location of the resources to the models folder. To stop the bleeding for correct APIs, we first fix the guideline setup now.
