### PR TITLE
Revert "Use build badge from GitHub Actions"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,6 @@
 = Developing Restful APIs: A Comprehensive Set of Guidelines by Zalando
 
-
-https://github.com/zalando/restful-api-guidelines/actions/[image:https://github.com/zalando/restful-api-guidelines/actions/workflows/build.yml/badge.svg]
+https://travis-ci.org/zalando/restful-api-guidelines[image:https://travis-ci.org/zalando/restful-api-guidelines.svg?branch=master[Build Status]]
 Latest published version:
 http://zalando.github.io/restful-api-guidelines/[*HTML*],
 http://zalando.github.io/restful-api-guidelines/zalando-guidelines.pdf[*PDF*],


### PR DESCRIPTION
Reverts zalando/restful-api-guidelines#675

Not working as expected.

![image](https://user-images.githubusercontent.com/18184975/125453257-a4893391-7f60-43cf-a8a3-0762538b652a.png)
