### PR TITLE
fix badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = Developing Restful APIs: A Comprehensive Set of Guidelines by Zalando
 
 
-https://github.com/zalando/restful-api-guidelines/actions/[image:https://github.com/zalando/restful-api-guidelines/actions/workflows/build.yml/badge.svg]
+https://github.com/zalando/restful-api-guidelines/actions/[image:https://github.com/zalando/restful-api-guidelines/actions/workflows/build.yml/badge.svg[Build status]]
 Latest published version:
 http://zalando.github.io/restful-api-guidelines/[*HTML*],
 http://zalando.github.io/restful-api-guidelines/zalando-guidelines.pdf[*PDF*],


### PR DESCRIPTION
This was changed previously in #675 and rolled back in #676.

It looks like in ASCIIdoc syntax, the image needs a title text to actually work.