### PR TITLE
Use only standard HTTP status codes registered via IANA

### DIFF
--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -44,20 +44,18 @@ service client and provider performance.
 [#150]
 == {MUST} use standard HTTP status codes
 
-You must only use official HTTP status codes standardized by RFCs consistently 
-with their intended semantics. 
-
-RFC standards define ~60 HTTP status codes with specific semantics all registered in the 
+You must only use official HTTP status codes consistently with their intended semantics. 
+Official HTTP status codes are defined via RFC standards and registered in the 
 https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml[IANA Status Code Registry].
-Main standards are {RFC-7231}#section-6[RFC7231] and {RFC-6585}[RFC 6585] (and there are upcoming new ones, e.g. 
+Main RFC standards are {RFC-7231}#section-6[RFC7231] and {RFC-6585}[RFC 6585] (and there are upcoming new ones, e.g. 
 https://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-05[draft legally-restricted-status]).
-See an overview on all official error codes e.g. on
-https://en.wikipedia.org/wiki/List_of_HTTP_status_codes[Wikipedia] 
+An overview on the official error codes e.g. provides 
+https://en.wikipedia.org/wiki/List_of_HTTP_status_codes[Wikipedia: HTTP status codes] 
 (which also lists some unofficial codes e.g. defined by popular web servers like Nginx).
 
-Below we list the most commonly used and best understood HTTP status codes,
-consistent with their semantic in the RFCs. APIs should only use these to
-prevent misconceptions that arise from less commonly used HTTP status codes.
+Below we list the subset of official codes that is _most commonly used_ and _best understood_,
+consistent with their semantic in the RFCs. You should only use these HTTP status codes to
+prevent misconceptions that often arise from less commonly used codes.
 
 **Important:** As long as your HTTP status code usage is well covered by the
 semantic defined here, you should not describe it to avoid an overload with

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -41,8 +41,8 @@ API specification. This can reduce service support tasks and contribute to
 service client and provider performance.
 
 
-[#150]
-== {MUST} use standard HTTP status codes
+[#243]
+== {MUST} use official HTTP status codes
 
 You must only use official HTTP status codes consistently with their intended semantics. 
 Official HTTP status codes are defined via RFC standards and registered in the 
@@ -53,9 +53,13 @@ An overview on the official error codes e.g. provides
 https://en.wikipedia.org/wiki/List_of_HTTP_status_codes[Wikipedia: HTTP status codes] 
 (which also lists some unofficial codes e.g. defined by popular web servers like Nginx).
 
-Below we list the subset of official codes that is _most commonly used_ and _best understood_,
-consistent with their semantic in the RFCs. You should only use these HTTP status codes to
-prevent misconceptions that often arise from less commonly used codes.
+[#150]
+== {SHOULD} only use most common HTTP status codes
+
+The most commonly used codes are best understood and listed below as subset of 
+the official HTTP status codes and consistent with their semantics in the RFCs. 
+We avoid less commonly used codes that easily create misconceptions due to 
+less familar semantics and API specific interpretations. 
 
 **Important:** As long as your HTTP status code usage is well covered by the
 semantic defined here, you should not describe it to avoid an overload with
@@ -63,7 +67,6 @@ common sense information and the risk of inconsistent definitions. Only if the
 HTTP status code is not in the list below or its usage requires additional
 information aside the well defined semantic, the API specification must provide
 a clear description of the HTTP status code in the response.
-
 
 [[success-codes]]
 === Success codes

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -44,17 +44,16 @@ service client and provider performance.
 [#150]
 == {MUST} use standard HTTP status codes
 
-You must only use standardized HTTP status codes consistently with their
-intended semantics. You must not invent new HTTP status codes.
+You must only use official HTTP status codes standardized by RFCs consistently 
+with their intended semantics. 
 
-RFC standards define ~60 different HTTP status codes with specific semantics 
-(mainly {RFC-7231}#section-6[RFC7231] and {RFC-6585}[RFC 6585]) — and there
-are upcoming new ones, e.g.
-https://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-05[draft
-legally-restricted-status]. See overview on all error codes on
-https://en.wikipedia.org/wiki/List_of_HTTP_status_codes[Wikipedia] or
-via https://httpstatuses.com/) also inculding 'unofficial codes', e.g. used
-by popular web servers like Nginx.
+RFC standards define ~60 HTTP status codes with specific semantics all registered in the 
+https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml[IANA Status Code Registry].
+Main standards are {RFC-7231}#section-6[RFC7231] and {RFC-6585}[RFC 6585] (and there are upcoming new ones, e.g. 
+https://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-05[draft legally-restricted-status]).
+See an overview on all official error codes e.g. on
+https://en.wikipedia.org/wiki/List_of_HTTP_status_codes[Wikipedia] 
+(which also lists some unofficial codes e.g. defined by popular web servers like Nginx).
 
 Below we list the most commonly used and best understood HTTP status codes,
 consistent with their semantic in the RFCs. APIs should only use these to


### PR DESCRIPTION
Be more specific about 'standard HTTP status code' -- must be standardized via RFC and registered via IANA Code Registry.