### PR TITLE
rename example:  order_id --> sales_order_number

### DIFF
--- a/chapters/naming.adoc
+++ b/chapters/naming.adoc
@@ -104,7 +104,7 @@ Examples:
 
 [source]
 ----
-customer_number, order_id, billing_address
+customer_number, sales_order_number, billing_address
 ----
 
 


### PR DESCRIPTION
Example contributes to promote usage of more specific `sales_order_number`(instead of `order_number` used for different resources like sales_orders, shipment_orders, purchase_orders) naming.