### PR TITLE
feat: migrate master to main (#706)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,12 @@
 name: Build
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the main branch
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build_docs:    
@@ -22,21 +22,21 @@ jobs:
 
       - name: Get Github Token
         id: get-gh-token
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: vadeg/github-app-token-action@v0.0.1
         with:
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           application_id: ${{ secrets.APP_ID }}
 
       - name: Create Zally Issues
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         env:
           GH_TOKEN: ${{ steps.get-gh-token.outputs.gh_access_token }}
         run: |
           scripts/create-zally-issue.sh
 
       - name: Deploy to GitHub Pages
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fixes #706.

Build is failing since we migrated from `master` to `main`, because github actions still referred to `master` branch.