### PR TITLE
clean-up 'internal links'

### DIFF
--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -27,8 +27,7 @@ event type and the schema for its custom data.
 
 The basic model described above was originally developed in the
 https://github.com/zalando/nakadi[Nakadi project], which acts as a
-reference implementation (see also
-https://apis.zalando.net/apis/nakadi-event-bus-api-definition/ui[Nakadi API[internal link]])
+reference implementation (see also {nakadi-api}[Nakadi API (internal_link)])
 of the event type registry, and as a validating
 publish/subscribe broker for event producers and consumers.
 

--- a/chapters/general-guidelines.adoc
+++ b/chapters/general-guidelines.adoc
@@ -13,12 +13,12 @@ You must follow the <<api-first, API First Principle>>, more specifically:
 * You must define APIs first, before coding its implementation, <<101, using
   OpenAPI as specification language>>
 * You must design your APIs consistently with these guidelines; use our
-  https://zally.zalando.net/[API Linter Service [internal link]] for automated
-  rule checks.
-* You must call for early review feedback from peers and client developers,
-  and apply https://github.bus.zalan.do/ApiGuild/ApiReviewProcedure[our
-  lightweight API review process [internal link]] for all component external
-  APIs, i.e. all apis with `x-api-audience =/= component-internal` (see <<219>>).
+  https://zally.zalando.net/[API Linter Service [internal link]] 
+  for automated rule checks.
+* You must call for early review feedback from peers and client developers, and apply 
+  https://github.bus.zalan.do/ApiGuild/ApiReviewProcedure[our lightweight API review process [internal link]] 
+  for all component external APIs, i.e. all apis 
+  with `x-api-audience =/= component-internal` (see <<219>>).
 
 
 [#101]
@@ -35,8 +35,7 @@ code management system - best together with the implementing sources.
 
 You <<192, must / should publish>> the component <<219, external / internal>>
 API specification with the deployment of the implementing service, and, hence,
-make it discoverable for the group via our https://apis.zalando.net/[API Portal
-[internal link]].
+make it discoverable for the group via our https://apis.zalando.net/[API Portal [internal link]].
 
 *Hint:* A good way to explore *OpenAPI 3.0/2.0* is to navigate through the
 https://openapi-map.apihandyman.io/[OpenAPI specification mind map] and use
@@ -46,8 +45,9 @@ existing APIs the https://editor.swagger.io/[Swagger Editor] or our
 https://apis.zalando.net[API Portal] may be a good starting point.
 
 *Hint:* We do not yet provide guidelines for https://graphql.org/[GraphQL].
-Following our https://techradar.zalando.net/languages/graphql.html[Zalando
-Tech Radar [internal link]], we focus on resource oriented HTTP/REST API style
+Following our 
+https://techradar.zalando.net/languages/graphql.html[Zalando Tech Radar [internal link]], 
+we focus on resource oriented HTTP/REST API style
 (and related tooling and infrastructure support) for general purpose
 peer-to-peer microservice communication. Here, we think that GraphQL has no
 major benefits, but a couple of downsides compared to REST. However, GraphQL
@@ -93,12 +93,12 @@ unexpected ways.
 However, you may use remote references to resources accessible by the following
 service URLs:
 
-* `https://infrastructure-api-repository.zalandoapis.com/` {dash} used to refer
-  to user defined, immutable API specification revisions published via the
+* `https://infrastructure-api-repository.zalandoapis.com/ (internal link)` {dash} used 
+  to refer to user defined, immutable API specification revisions published via the
   internal API repository.
-* `https://opensource.zalando.com/restful-api-guidelines/{model.yaml}` {dash}
-  used to refer to guideline defined re-usable API fragments (see
-  `{model.yaml}` files in https://github.com/zalando/restful-api-guidelines/tree/master/models[restful-api-guidelines/models]
+* `https://opensource.zalando.com/restful-api-guidelines/{model.yaml}` {dash} used 
+  to refer to guideline defined re-usable API fragments (see `{model.yaml}` files in 
+  https://github.com/zalando/restful-api-guidelines/tree/master/models[restful-api-guidelines/models]
   for details).
 
 *Hint:* The formerly used remote references to the `Problem` API fragment

--- a/chapters/general-guidelines.adoc
+++ b/chapters/general-guidelines.adoc
@@ -13,10 +13,10 @@ You must follow the <<api-first, API First Principle>>, more specifically:
 * You must define APIs first, before coding its implementation, <<101, using
   OpenAPI as specification language>>
 * You must design your APIs consistently with these guidelines; use our
-  https://zally.zalando.net/[API Linter Service [internal link]] 
+  {zally-ui}[API Linter Service (internal_link)] 
   for automated rule checks.
 * You must call for early review feedback from peers and client developers, and apply 
-  https://github.bus.zalan.do/ApiGuild/ApiReviewProcedure[our lightweight API review process [internal link]] 
+  {api-review-proc}[our lightweight API review process (internal_link)] 
   for all component external APIs, i.e. all apis 
   with `x-api-audience =/= component-internal` (see <<219>>).
 
@@ -35,7 +35,7 @@ code management system - best together with the implementing sources.
 
 You <<192, must / should publish>> the component <<219, external / internal>>
 API specification with the deployment of the implementing service, and, hence,
-make it discoverable for the group via our https://apis.zalando.net/[API Portal [internal link]].
+make it discoverable for the group via our {api-portal}[API Portal (internal_link)].
 
 *Hint:* A good way to explore *OpenAPI 3.0/2.0* is to navigate through the
 https://openapi-map.apihandyman.io/[OpenAPI specification mind map] and use
@@ -45,8 +45,7 @@ existing APIs the https://editor.swagger.io/[Swagger Editor] or our
 https://apis.zalando.net[API Portal] may be a good starting point.
 
 *Hint:* We do not yet provide guidelines for https://graphql.org/[GraphQL].
-Following our 
-https://techradar.zalando.net/languages/graphql.html[Zalando Tech Radar [internal link]], 
+Following our {techradar-public}[Zalando Tech Radar (internal_link)], 
 we focus on resource oriented HTTP/REST API style
 (and related tooling and infrastructure support) for general purpose
 peer-to-peer microservice communication. Here, we think that GraphQL has no
@@ -93,7 +92,7 @@ unexpected ways.
 However, you may use remote references to resources accessible by the following
 service URLs:
 
-* `https://infrastructure-api-repository.zalandoapis.com/ (internal link)` {dash} used 
+* `{api-repository} (internal_link)` {dash} used 
   to refer to user defined, immutable API specification revisions published via the
   internal API repository.
 * `https://opensource.zalando.com/restful-api-guidelines/{model.yaml}` {dash} used 

--- a/chapters/http-headers.adoc
+++ b/chapters/http-headers.adoc
@@ -471,13 +471,12 @@ format or length, it must define this restriction in its API specification,
 and be generous and remove invalid characters or cut the length to the
 supported limit.
 
-*Hint:* In case distributed tracing is supported by {SRE-Tracing}[OpenTracing
-(internal link)] you should ensure that created _spans_ are tagged using
-`flow_id` — see
-{SRE-Tracing}/blob/master/wg-semantic-conventions/best-practices/flowid.md[How
-to Connect Log Output with OpenTracing Using Flow-IDs (internal link)] or
-{SRE-Tracing}/blob/master/wg-semantic-conventions/best-practices.md[Best
-practises (internal link)].
+*Hint:* In case distributed tracing is supported by 
+https://github.bus.zalan.do/SRE/opentracing[OpenTracing (internal link)] 
+you should ensure that created _spans_ are tagged using `flow_id` — see
+https://github.bus.zalan.do/SRE/opentracing/blob/master/wg-semantic-conventions/best-practices/flowid.md[How to Connect Log Output with OpenTracing Using Flow-IDs (internal link)] 
+or
+https://github.bus.zalan.do/SRE/opentracing/blob/master/wg-semantic-conventions/best-practices.md[Best practises (internal link)].
 
 === Service Guidance
 

--- a/chapters/http-headers.adoc
+++ b/chapters/http-headers.adoc
@@ -349,8 +349,7 @@ a request from a Business Partner hits the Zalando Platform.
 |[[x-sales-channel]]{X-Sales-Channel}|String|
 Sales channels are owned by retailers and represent a specific consumer segment
 being addressed with a specific product assortment that is offered via CFA
-retailer catalogs to consumers (see
-https://digital-experience.docs.zalando.net/glossary/glossary.html[fashion platform glossary (internal link)]).
+retailer catalogs to consumers (see {glossary}[fashion platform glossary (internal_link)]).
 |52b96501-0f8d-43e7-82aa-8a96fab134d7
 
 |[[x-frontend-type]]{X-Frontend-Type}|String|
@@ -472,11 +471,11 @@ and be generous and remove invalid characters or cut the length to the
 supported limit.
 
 *Hint:* In case distributed tracing is supported by 
-https://github.bus.zalan.do/SRE/opentracing[OpenTracing (internal link)] 
+{SRE-open-tracing}[OpenTracing (internal_link)] 
 you should ensure that created _spans_ are tagged using `flow_id` — see
-https://github.bus.zalan.do/SRE/opentracing/blob/master/wg-semantic-conventions/best-practices/flowid.md[How to Connect Log Output with OpenTracing Using Flow-IDs (internal link)] 
+{SRE-open-tracing}/blob/master/wg-semantic-conventions/best-practices/flowid.md[How to Connect Log Output with OpenTracing Using Flow-IDs (internal_link)] 
 or
-https://github.bus.zalan.do/SRE/opentracing/blob/master/wg-semantic-conventions/best-practices.md[Best practises (internal link)].
+{SRE-open-tracing}/blob/master/wg-semantic-conventions/best-practices.md[Best practises (internal_link)].
 
 === Service Guidance
 

--- a/chapters/hyper-media.adoc
+++ b/chapters/hyper-media.adoc
@@ -63,8 +63,7 @@ However, we do not forbid HATEOAS; you could use it, if you checked its
 limitations and still see clear value for your usage scenario that justifies
 its additional complexity. If you use HATEOAS please share experience and
 present your findings in the
-https://confluence.zalando.net/display/GUL/API+Guild[API Guild [internal
-link]].
+https://api.docs.zalando.net/[API Guild [internal link]].
 
 
 [#164]

--- a/chapters/hyper-media.adoc
+++ b/chapters/hyper-media.adoc
@@ -62,8 +62,7 @@ HATEOAS] and others for a detailed discussion):
 However, we do not forbid HATEOAS; you could use it, if you checked its
 limitations and still see clear value for your usage scenario that justifies
 its additional complexity. If you use HATEOAS please share experience and
-present your findings in the
-https://api.docs.zalando.net/[API Guild [internal link]].
+present your findings in the {api-guild}[API Guild (internal_link)].
 
 
 [#164]
@@ -95,9 +94,9 @@ HttpLink:
 ----
 
 The name of an attribute holding such a `HttpLink` object specifies the
-relation between the object that contains the link and the linked
-resource. Implementations should use names from the {link-relations}[IANA
-Link Relation Registry] whenever appropriate. As IANA link relation
+relation between the object that contains the link and the linked resource. 
+Implementations should use names from the {iana-link-relations}[IANA Link Relation Registry] 
+whenever appropriate. As IANA link relation
 names use hyphen-case notation, while this guide enforces snake_case
 notation for attribute names, hyphens in IANA names have to be replaced
 with underscores (e.g. the IANA link relation type `version-history`
@@ -141,7 +140,7 @@ understandability and usability of an API.
 For pagination and self-references a simplified form of the <<164, extensible
 common hypertext controls>> should be used to reduce the specification and
 cognitive overhead. It consists of a simple URI value in combination with the
-corresponding {link-relations}[link relations], e.g. {next}, {prev}, {first},
+corresponding {iana-link-relations}[link relations], e.g. {next}, {prev}, {first},
 {last}, or {self}.
 
 See <<164>> and <<161>> for more information and examples.

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -45,8 +45,8 @@ interpreted as described in https://www.ietf.org/rfc/rfc2119.txt[RFC
 
 The purpose of our "RESTful API guidelines" is to define standards to
 successfully establish "consistent API look and feel" quality. The
-https://confluence.zalando.net/display/GUL/API+Guild[API Guild [internal
-link]] drafted and owns this document. Teams are responsible to fulfill
+https://api.docs.zalando.net/[API Guild [internal link]] 
+drafted and owns this document. Teams are responsible to fulfill
 these guidelines during API development and are encouraged to contribute
 to guideline evolution via pull requests.
 

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -45,7 +45,7 @@ interpreted as described in https://www.ietf.org/rfc/rfc2119.txt[RFC
 
 The purpose of our "RESTful API guidelines" is to define standards to
 successfully establish "consistent API look and feel" quality. The
-https://api.docs.zalando.net/[API Guild [internal link]] 
+{api-guild}[API Guild (internal_link)] 
 drafted and owns this document. Teams are responsible to fulfill
 these guidelines during API development and are encouraged to contribute
 to guideline evolution via pull requests.

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -48,7 +48,7 @@ for specific use cases where clients may not interpret the payload structure.
 [#172]
 == {SHOULD} use standard media types
 
-You should use standard media types (defined in {media-types}[media type registry]
+You should use standard media types (defined in {iana-media-types}[media type registry]
 of Internet Assigned Numbers Authority (IANA)) as `content-type` (or `accept`) header
 information. More specifically, for JSON payload you should use the standard media type
 `application/json` (or `application/problem+json` for <<176>>).
@@ -262,7 +262,7 @@ We define the following common field names:
   *Exception*: We use `customer_number` instead of `customer_id` for customer facing
   identification of customers due to legacy reasons. (Hint: `customer_id` used to be defined
   as internal only, technical integer key, see
-  https://apis.zalando.net/redirect/5675b6ec-8934-11ea-929e-68f728c1ba70[Naming Decision: `customer_number` vs `customer_id` [internal link]]).
+  {customer-naming-decision}[Naming Decision: `customer_number` vs `customer_id` [internal_link]]).
 * [[type]]{type}: the kind of thing this object is. If used, the type of this
   field should be a string. Types allow runtime information on the entity
   provided that otherwise requires examining the OpenAPI file.

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -262,8 +262,7 @@ We define the following common field names:
   *Exception*: We use `customer_number` instead of `customer_id` for customer facing
   identification of customers due to legacy reasons. (Hint: `customer_id` used to be defined
   as internal only, technical integer key, see
-  https://apis.zalando.net/redirect/5675b6ec-8934-11ea-929e-68f728c1ba70[Naming
-  Decision: `customer_number` vs `customer_id` [internal link]]).
+  https://apis.zalando.net/redirect/5675b6ec-8934-11ea-929e-68f728c1ba70[Naming Decision: `customer_number` vs `customer_id` [internal link]]).
 * [[type]]{type}: the kind of thing this object is. If used, the type of this
   field should be a string. Types allow runtime information on the entity
   provided that otherwise requires examining the OpenAPI file.

--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -160,8 +160,7 @@ reason a smaller audience group is intentionally included in the wider group
 and thus does not need to be declared additionally. If parts of your API have
 a different target audience, we recommend to split API specifications along
 the target audience — even if this creates redundancies
-(https://apis.zalando.net/redirect/85ee93a3-7a78-4461-8bf1-08ffdaebcd18[rationale
-(internal link)]).
+(https://apis.zalando.net/redirect/85ee93a3-7a78-4461-8bf1-08ffdaebcd18[rationale (internal link)]).
 
 Example:
 
@@ -177,8 +176,7 @@ info:
 ----
 
 For details and more information on audience groups see the
-https://apis.zalando.net/redirect/85ee93a3-7a78-4461-8bf1-08ffdaebcd18[
-API Audience narrative (internal link)].
+https://apis.zalando.net/redirect/85ee93a3-7a78-4461-8bf1-08ffdaebcd18[API Audience narrative (internal link)].
 
 
 [#223]
@@ -221,8 +219,8 @@ Please see the following rules for detailed functional naming patterns:
 
 
 *Internal Guideance*:  You _must_ use the simple
-https://github.bus.zalan.do/team-architecture/functional-component-registry[functional
-name registry (internal link)] to register your functional name before using
+https://github.bus.zalan.do/team-architecture/functional-component-registry[functional name registry (internal link)] 
+to register your functional name before using
 it. The registry is a centralized infrastructure service to ensure uniqueness
 of your functional names (and available domains -- including subdomains) and
 to support hostname DNS resolution. +

--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -160,7 +160,7 @@ reason a smaller audience group is intentionally included in the wider group
 and thus does not need to be declared additionally. If parts of your API have
 a different target audience, we recommend to split API specifications along
 the target audience — even if this creates redundancies
-(https://apis.zalando.net/redirect/85ee93a3-7a78-4461-8bf1-08ffdaebcd18[rationale (internal link)]).
+({api-audience-narrative}[rationale (internal_link)]).
 
 Example:
 
@@ -176,7 +176,7 @@ info:
 ----
 
 For details and more information on audience groups see the
-https://apis.zalando.net/redirect/85ee93a3-7a78-4461-8bf1-08ffdaebcd18[API Audience narrative (internal link)].
+{api-audience-narrative}[API Audience narrative (internal_link)].
 
 
 [#223]
@@ -219,7 +219,7 @@ Please see the following rules for detailed functional naming patterns:
 
 
 *Internal Guideance*:  You _must_ use the simple
-https://github.bus.zalan.do/team-architecture/functional-component-registry[functional name registry (internal link)] 
+{functional-name-registry}[functional name registry (internal_link)] 
 to register your functional name before using
 it. The registry is a centralized infrastructure service to ensure uniqueness
 of your functional names (and available domains -- including subdomains) and

--- a/index.adoc
+++ b/index.adoc
@@ -15,6 +15,7 @@
 :dash: pass:[<b>–</b>]
 
 // Some link short cuts.
+// links to RFCs and standards:
 :RFC-1034: https://tools.ietf.org/html/rfc1034
 :RFC-2616: https://tools.ietf.org/html/rfc2616
 :RFC-2673: https://tools.ietf.org/html/rfc2673
@@ -49,9 +50,8 @@
 :RFC-8288: https://tools.ietf.org/html/rfc8288
 :RFC-8594: https://tools.ietf.org/html/rfc8594
 
-:link-relations: http://www.iana.org/assignments/link-relations
-:media-types: https://www.iana.org/assignments/media-types/media-types.xhtml
-
+:iana-link-relations: http://www.iana.org/assignments/link-relations
+:iana-media-types: https://www.iana.org/assignments/media-types/media-types.xhtml
 :BCP47: https://tools.ietf.org/html/bcp47
 :ECMA-262: http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf
 :GTIN: https://en.wikipedia.org/wiki/Global_Trade_Item_Number
@@ -60,6 +60,20 @@
 :ISO-3166-1-a2: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 :ISO-639-1: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 :ISO-4217: https://en.wikipedia.org/wiki/ISO_4217
+
+// links to internal 
+:api-guild: https://api.docs.zalando.net/
+:nakadi-api: https://apis.zalando.net/apis/nakadi-event-bus-api-definition/ui
+:api-audience-narrative: https://apis.zalando.net/redirect/85ee93a3-7a78-4461-8bf1-08ffdaebcd18
+:functional-name-registry: https://github.bus.zalan.do/team-architecture/functional-component-registry
+:customer-naming-decision: https://apis.zalando.net/redirect/5675b6ec-8934-11ea-929e-68f728c1ba70
+:zally-ui: https://zally.zalando.net/
+:api-review-proc: https://api.docs.zalando.net/howto/request-review/
+:api-portal: https://apis.zalando.net/
+:techradar-public: https://techradar.zalando.net/languages/graphql.html
+:api-repository: https://infrastructure-api-repository.zalandoapis.com/
+:glossary: https://digital-experience.docs.zalando.net/glossary/glossary.html
+:SRE-open-tracing: https://github.bus.zalan.do/SRE/opentracing
 
 // Attribute to improve design of key words in titles.
 :MUST: pass:[<span class="must-keyword"><strong>MUST</strong></span>]
@@ -88,7 +102,6 @@
 :OPTIONS: pass:[<a href="#options"><code>OPTIONS</code></a>]
 :TRACE: pass:[<a href="#trace"><code>TRACE</code></a>]
 :ALL: pass:[<code>&lt;all&gt;</code>]
-
 
 
 // Attributes to improve design and linking of HTTP status codes

--- a/index.adoc
+++ b/index.adoc
@@ -61,8 +61,6 @@
 :ISO-639-1: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 :ISO-4217: https://en.wikipedia.org/wiki/ISO_4217
 
-:SRE-Tracing: https://github.bus.zalan.do/SRE/opentracing
-
 // Attribute to improve design of key words in titles.
 :MUST: pass:[<span class="must-keyword"><strong>MUST</strong></span>]
 :SHOULD: pass:[<span class="should-keyword"><strong>SHOULD</strong></span>]


### PR DESCRIPTION
updated: links to new API Guild docu
editorial: make sure that all internal links are grep-able (i.e. single lined) for easy checks