### PR TITLE
Fix capitalization of X-Device-* headers.

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -162,8 +162,8 @@
 :X-Tenant-ID: pass:[<a href="#x-tenant-id"><code>X-Tenant-ID</code></a>]
 :X-Sales-Channel: pass:[<a href="#x-sales-channel"><code>X-Sales-Channel</code></a>]
 :X-Frontend-Type: pass:[<a href="#x-frontend-type"><code>X-Frontend-Type</code></a>]
-:X-Device-Type: pass:[<a href="#x-device-type"><code>X-device-Type</code></a>]
-:X-Device-OS: pass:[<a href="#x-device-os"><code>X-device-OS</code></a>]
+:X-Device-Type: pass:[<a href="#x-device-type"><code>X-Device-Type</code></a>]
+:X-Device-OS: pass:[<a href="#x-device-os"><code>X-Device-OS</code></a>]
 :X-Mobile-Advertising-ID: pass:[<a href="#x-mobile-advertising-id"><code>X-Mobile-Advertising-ID</code></a>]
 :X-App-Domain: pass:[<a href="#x-app-domain"><code>X-App-Domain</code></a>]
 


### PR DESCRIPTION
This typo in the formatting code affects how the header name is rendered in rule https://opensource.zalando.com/restful-api-guidelines/#183.

Thanks to @raiskumar for pointing this out (in an internal chat).