### PR TITLE
More master→main fixes

### DIFF
--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -336,11 +336,11 @@ the Schema Object as defined by the OpenAPI Specifications to define event
 schemas. This is particularly useful for events that represent data changes
 about resources also used in other APIs.
 
-The https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject[OpenAPI Schema Object]
+The https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#schemaObject[OpenAPI Schema Object]
 is an **extended subset** of
 http://json-schema.org/[JSON Schema Draft 4]. For convenience,
 we highlight some important differences below. Please refer to the
-https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject[OpenAPI Schema Object specification]
+https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#schemaObject[OpenAPI Schema Object specification]
 for details.
 
 As the OpenAPI Schema Object specification _removes_ some JSON Schema
@@ -367,7 +367,7 @@ Finally, the Schema Object _extends_ JSON Schema with some keywords:
 considered redundant, but harmless.
 * `discriminator`: to support polymorphism, as an alternative to `oneOf`.
 * `^x-`: patterned objects in the form of
-https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#vendorExtensions[vendor
+https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#vendorExtensions[vendor
 extensions] can be used in event type schema, but it might be the case
 that general purpose validators do not understand them to enforce a
 validation check, and fall back to must-ignore processing. A future

--- a/chapters/general-guidelines.adoc
+++ b/chapters/general-guidelines.adoc
@@ -88,7 +88,7 @@ should not contain references to local or remote content, e.g. `../fragment.yaml
 `$ref: 'https://github.com/zalando/zally/blob/master/server/src/main/resources/api/zally-api.yaml#/schemas/LintingRequest'`.
 The reason is, that the content referred to is _in general_ *not durable* and
 *not immutable*. As a consequence, the semantic of an API may change in
-unexpected ways. (For example, the second link is already outdated due to code restructuring, it would now need to be `$ref: 'https://github.com/zalando/zally/blob/main/server/zally-server/src/main/resources/api/zally-api.yaml#/schemas/LintingRequest'`.)
+unexpected ways. (For example, the second link is already outdated due to code restructuring.)
 
 However, you may use remote references to resources accessible by the following
 service URLs:

--- a/chapters/general-guidelines.adoc
+++ b/chapters/general-guidelines.adoc
@@ -88,7 +88,7 @@ should not contain references to local or remote content, e.g. `../fragment.yaml
 `$ref: 'https://github.com/zalando/zally/blob/master/server/src/main/resources/api/zally-api.yaml#/schemas/LintingRequest'`.
 The reason is, that the content referred to is _in general_ *not durable* and
 *not immutable*. As a consequence, the semantic of an API may change in
-unexpected ways.
+unexpected ways. (For example, the second link is already outdated due to code restructuring, it would now need to be `$ref: 'https://github.com/zalando/zally/blob/main/server/zally-server/src/main/resources/api/zally-api.yaml#/schemas/LintingRequest'`.)
 
 However, you may use remote references to resources accessible by the following
 service URLs:
@@ -98,7 +98,7 @@ service URLs:
   internal API repository.
 * `https://opensource.zalando.com/restful-api-guidelines/{model.yaml}` {dash}
   used to refer to guideline defined re-usable API fragments (see
-  `{model.yaml}` files in https://github.com/zalando/restful-api-guidelines/tree/master/models[restful-api-guidelines/models]
+  `{model.yaml}` files in https://github.com/zalando/restful-api-guidelines/tree/main/models[restful-api-guidelines/models]
   for details).
 
 *Hint:* The formerly used remote references to the `Problem` API fragment

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -95,7 +95,7 @@ or write is sufficient.
 
 The defined permissions are than assigned to each API endpoint based on the
 security schema (see example in <<104, previous section>>) by specifying the
-https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityRequirementObject[security requirement]
+https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#securityRequirementObject[security requirement]
 as follows:
 
 [source,yaml]

--- a/chapters/urls.adoc
+++ b/chapters/urls.adoc
@@ -18,7 +18,7 @@ you to maintain two different API specifications and provide
 
 We see API's base path as a part of deployment variant configuration.
 Therefore, this information has to be declared in the
-https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#server-object[server object].
+https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#server-object[server object].
 
 
 [#134]


### PR DESCRIPTION
* rename master→main in one reference to this repository (leftover from #706)
* rename master→main in links to the OpenAPI spec repository
* add a comment to one URL which is broken

Ironically, the other occurrence of `master` in an URL (some lines above the fix) was already broken due to another change, and also in an example of why not to use such links, so I decided to just leave it here.

There are two `master` URLs left, they are for a Zalando-internal repository which was not yet changed.