### PR TITLE
Exclude 'type' from common field names

### DIFF
--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -263,11 +263,8 @@ We define the following common field names:
   identification of customers due to legacy reasons. (Hint: `customer_id` used to be defined
   as internal only, technical integer key, see
   {customer-naming-decision}[Naming Decision: `customer_number` vs `customer_id` [internal_link]]).
-* [[type]]{type}: the kind of thing this object is. If used, the type of this
-  field should be a string. Types allow runtime information on the entity
-  provided that otherwise requires examining the OpenAPI file.
 * [[etag]]{etag}: the <<182, ETag>> of an <<158, embedded sub-resource>>. It
-  may be used to carry the {ETag} for subsequent {PUT}/{PATCH} calls (see
+  typically is used to carry the {ETag} for subsequent {PUT}/{PATCH} calls (see
   <<etag-in-result-entities>>).
 
 Further common fields are defined in <<235>>.
@@ -288,6 +285,9 @@ tree_node:
     id:
       description: the identifier of this node
       type: string
+    parent_node_id:
+      description: the identifier of the parent node of this node
+      type: string
     created_at:
       description: when got this node created
       type: string
@@ -296,18 +296,11 @@ tree_node:
       description: when got this node last updated
       type: string
       format: 'date-time'
-    type:
-      type: string
-      enum: [ 'LEAF', 'NODE' ]
-    parent_node_id:
-      description: the identifier of the parent node of this node
-      type: string
   example:
     id: '123435'
+    parent_node_id: '534321'
     created_at: '2017-04-12T23:20:50.52Z'
     modified_at: '2017-04-12T23:20:50.52Z'
-    type: 'LEAF'
-    parent_node_id: '534321'
 ----
 
 


### PR DESCRIPTION
Reasoning -- as discussed in the API Guild meeting: 
- its purpose is to be a discriminator for polymorphic types 
- not needed anymore since discriminators are supported by OpenAPI 3.x -- see https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/ 
- current definition and documentation is poor