### PR TITLE
Problem definition examples conflict with application contexts

### DIFF
--- a/models/problem-1.0.1.yaml
+++ b/models/problem-1.0.1.yaml
@@ -10,14 +10,14 @@ Problem:
         it is neither recommended to be dereferenceable and point to a
         human-readable documentation nor globally unique for the problem type.
       default: 'about:blank'
-      example: '/problem/connection-error'
+      example: '/some/uri-reference'   
     title:
       type: string
       description: >
         A short summary of the problem type. Written in English and readable
         for engineers, usually not suited for non technical stakeholders and
         not localized.
-      example: Service Unavailable
+      example: some title for the error situation
     status:
       type: integer
       format: int32
@@ -27,7 +27,6 @@ Problem:
       minimum: 100
       maximum: 600
       exclusiveMaximum: true
-      example: 503
     detail:
       type: string
       description: >
@@ -35,7 +34,7 @@ Problem:
         problem that is helpful to locate the problem and give advice on how
         to proceed. Written in English and readable for engineers, usually not
         suited for non technical stakeholders and not localized.
-      example: Connection to database timed out
+      example: some description for the error situation
     instance:
       type: string
       format: uri-reference
@@ -43,4 +42,4 @@ Problem:
         A URI reference that identifies the specific occurrence of the problem,
         e.g. by adding a fragment identifier or sub-path to the problem type.
         May be used to locate the root of this problem in the source code.
-      example: '/problem/connection-error#token-info-read-timed-out'
+      example: '/some/uri-reference#specific-occurence-context'


### PR DESCRIPTION
Deleted or substituted the examples with generic values.
The problem definition is generic and we guide to use it in all error return situations -- see https://opensource.zalando.com/restful-api-guidelines/#176 
Concrete example values in the problem definition lead to confusion because they conflict with the values valid in the application context of specific http status response definitions.