### PR TITLE
MUST --> SHOULD avoid providing sensitive data with events

### DIFF
--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -829,12 +829,12 @@ reason".
 
 [#200]
 == {SHOULD} avoid writing sensitive data to events
-Event data security is supported by Nakadi Event Bus mechanisms 
-for access control and authorization of publishing or consuming events. 
-However, we avoid writing sensitive data (e.g. personal data like e-mail or address) 
-to events unless it is needed for the business. 
-Sensitive data create additional obligations for access control and compliance and 
-generally increases data protection risks.
+
+Event data security is supported by Nakadi Event Bus mechanisms for access
+control and authorization of publishing or consuming events.  However, we avoid
+writing sensitive data (e.g. personal data like e-mail or address) to events unless
+it is needed for the business. Sensitive data create additional obligations for
+access control and compliance and generally increases data protection risks.
 
 
 [#214]

--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -828,18 +828,13 @@ reason".
 = EVENT Design
 
 [#200]
-== {MUST} ensure that events do not provide sensitive data
-
-Similar to API permission scopes, there will be event type permissions
-passed via an OAuth token supported in near future. In the meantime,
-teams are asked to note the following:
-
-* Sensitive data, such as (e-mail addresses, phone numbers, etc) are
-subject to strict access and data protection controls.
-* Event type owners *must not* publish sensitive information unless it's
-mandatory or necessary to do so. For example, events sometimes need to
-provide personal data, such as delivery addresses in shipment orders (as
-do other APIs), and this is fine.
+== {SHOULD} avoid writing sensitive data to events
+Event data security is supported by Nakadi Event Bus mechanisms 
+for access control and authorization of publishing or consuming events. 
+However, we avoid writing sensitive data (e.g. personal data like e-mail or address) 
+to events unless it is needed for the business. 
+Sensitive data create additional obligations for access control and compliance and 
+generally increases data protection risks.
 
 
 [#214]


### PR DESCRIPTION
* The rule does not reflect Nakadi status quo as it requires using scopes (provided with tokens for REST API like authorization, instead of supported mechanism based on access control lists maintained as part of the event type definition. 
* The statement to avoid sensitive data is a recommendation, and not a must rule.