### PR TITLE
Replace `warning` and `reasoning` with `note`

### DIFF
--- a/chapters/urls.adoc
+++ b/chapters/urls.adoc
@@ -73,7 +73,7 @@ You must not specify paths with duplicate or trailing slashes, e.g.
 `/customers//addresses` or `/customers/`. As a consequence, you must also not
 specify or use path variables with empty string values.
 
-*Reasoning:* Non standard paths have no clear semantics. As a result, behavior
+*Note:* Non standard paths have no clear semantics. As a result, behavior
 for non standard paths varies between different HTTP infrastructure components
 and libraries. This may leads to ambiguous and unexpected results during
 request handling and monitoring.
@@ -225,7 +225,7 @@ Example paths:
 /article-size-advices/{sku}/{sales-channel}
 ----
 
-**Warning:** Exposing a compound key as described above limits ability to
+*Note*: Exposing a compound key as described above limits ability to
 evolve the structure of the resource identifier as it is no longer opaque.
 
 To compensate for this drawback, APIs must apply a compound key abstraction


### PR DESCRIPTION
Replace `warning` and `reasoning` with note as a part of the ticket #660 to uniform hints and layout