### PR TITLE
feat: improve format and time interval guidance (#641)

### DIFF
--- a/chapters/best-practices.adoc
+++ b/chapters/best-practices.adoc
@@ -177,7 +177,7 @@ The ETag for every entity is returned as an additional property of that entity.
 In a response containing multiple entities, every entity will then have a
 distinct {ETag} that can be used in subsequent {PUT} requests.
 
-In this solution, the `etag` property should be `readonly` and never be expected
+In this solution, the {e_tag} property should be `readonly` and never be expected
 in the {PUT} request payload.
 
 Example:

--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -53,9 +53,9 @@ You *must* use these formats, whenever applicable:
 [cols="10%,10%,40%,40%",options="header",]
 |=====================================================================
 | `OpenAPI type` | `format` | Specification | Example
-| `string` | `iso-639` | two letter language code -- see {ISO-639-1}[ISO 639-1] | `"en"`
+| `string` | `iso-639-1` | two letter language code -- see {ISO-639-1}[ISO 639-1] | `"en"`
 | `string` | `bcp47` | multi letter language tag -- see {BCP47}[BCP 47]. It is a compatible extension of {ISO-639-1}[ISO 639-1] optionally with additional information for language usage, like region, variant, script. | `"en-DE"`
-| `string` | `iso-3166` | two letter country code -- see {ISO-3166-1-a2}[ISO 3166-1 alpha-2] | `"GB"`  *Hint:* It is `"GB"`, not `"UK"`, even though `"UK"` has seen some use at Zalando.
+| `string` | `iso-3166-alpha-2` | two letter country code -- see {ISO-3166-1-alpha-2}[ISO 3166-1 alpha-2] | `"GB"`  *Hint:* It is `"GB"`, not `"UK"`, even though `"UK"` has seen some use at Zalando.
 | `string` | `iso-4217` | three letter currency code -- see {ISO-4217}[ISO 4217] | `"EUR"`
 | `string` | `gtin-13` | Global Trade Item Number -- see {GTIN}[GTIN] | `"5710798389878"`
 | `string` | `regex` | regular expressions as defined in {ECMA-262}[ECMA 262] | `"^[a-z0-9]+$"`
@@ -121,9 +121,34 @@ more effort to parse, avoid this ambiguity.
 [#127]
 == {SHOULD} use standard formats for time duration and interval properties
 
-Schema based JSON properties that are by design durations and intervals could
-be strings formatted as defined by {ISO-8601}[ISO 8601]
-({RFC-3339}#appendix-A[Appendix A of RFC 3339 contains a grammar] for durations).
+Properties and that are by design durations and time intervals should be
+represented as strings formatted as defined by {ISO-8601}[ISO 8601]
+({RFC-3339}#appendix-A[RFC 3339 Appendix A contains a grammar] for `durations`
+and `periods` - the latter called time intervals in {ISO-8601}[ISO 8601]). ISO
+8601:1-2019 defines an  extension (`..`) to express open ended time intervals
+that are very convenient in searches and are included in the below grammar:
+
+[source,abnf]
+----
+   dur-second        = 1*DIGIT "S"
+   dur-minute        = 1*DIGIT "M" [dur-second]
+   dur-hour          = 1*DIGIT "H" [dur-minute]
+   dur-time          = "T" (dur-hour / dur-minute / dur-second)
+   dur-day           = 1*DIGIT "D"
+   dur-week          = 1*DIGIT "W"
+   dur-month         = 1*DIGIT "M" [dur-day]
+   dur-year          = 1*DIGIT "Y" [dur-month]
+   dur-date          = (dur-day / dur-month / dur-year) [dur-time]
+   duration          = "P" (dur-date / dur-time / dur-week)
+   
+   period-explicit   = iso-date-time "/" iso-date-time
+   period-start      = iso-date-time "/" (duration / "..")
+   period-end        = (duration / "..") "/" iso-date-time
+   period            = period-explicit / period-start / period-end
+----
+
+A time interval query parameters should use `*_between` instead of the tuple
+`*_before`/`*_after`, while properties should be named using `*_interval`.
 
 
 [#128]
@@ -132,16 +157,16 @@ be strings formatted as defined by {ISO-8601}[ISO 8601]
 
 As a specific case of <<238>> you must use the following standard formats:
 
-* Country codes: {ISO-3166-1-a2}[ISO 3166-1-alpha2] two letter country codes
-  indicated via OpenAPI format `iso-3166`
-* Language codes: {ISO-639-1}[ISO 639-1] two letter language codes
-  indicated via OpenAPI format `iso-639`
-* Language variant tags: {BCP47}[BCP 47] multi letter language tag
-  indicated via OpenAPI format `bcp47`. (It is a compatible extension of
-  {ISO-639-1}[ISO 639-1] with additional optional
-  information for language usage, like region, variant, script)
-* Currency codes:  {ISO-4217}[ISO 4217] three letter currency codes
-   indicated via OpenAPI format `iso-4217`
+* Country codes: {ISO-3166-1-alpha-2}[ISO 3166-1-alpha-2] two letter country
+  codes indicated via format `iso-3166-alpha-2` in the OpenAPI specification.
+* Language codes: {ISO-639-1}[ISO 639-1] two letter language codes indicated
+  via format `iso-639-1` in the OpenAPI specification.
+* Language variant tags: {BCP47}[BCP 47] multi letter language tag indicated
+  via format `bcp47` in the OpenAPI specification. (It is a compatible extension
+  of {ISO-639-1}[ISO 639-1] with additional optional information for language
+  usage, like region, variant, script)
+* Currency codes:  {ISO-4217}[ISO 4217] three letter currency codes indicated
+  via format `iso-4217` in the OpenAPI specification.
 
 [#244]
 == {SHOULD} use content negotiation, if clients may choose from different resource representations

--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -53,9 +53,9 @@ You *must* use these formats, whenever applicable:
 [cols="10%,10%,40%,40%",options="header",]
 |=====================================================================
 | `OpenAPI type` | `format` | Specification | Example
-| `string` | `iso-639-1` | two letter language code -- see {ISO-639-1}[ISO 639-1] | `"en"`
+| `string` | `iso-639-1`| two letter language code -- see {ISO-639-1}[ISO 639-1]. Hint: In the past we used `iso-639` as format. | `"en"`
 | `string` | `bcp47` | multi letter language tag -- see {BCP47}[BCP 47]. It is a compatible extension of {ISO-639-1}[ISO 639-1] optionally with additional information for language usage, like region, variant, script. | `"en-DE"`
-| `string` | `iso-3166-alpha-2` | two letter country code -- see {ISO-3166-1-alpha-2}[ISO 3166-1 alpha-2] | `"GB"`  *Hint:* It is `"GB"`, not `"UK"`, even though `"UK"` has seen some use at Zalando.
+| `string` | `iso-3166-alpha-2` | two letter country code -- see {ISO-3166-1-alpha-2}[ISO 3166-1 alpha-2]. Hint: In the past we used `iso-3166` as format. | `"GB"`  *Hint:* It is `"GB"`, not `"UK"`, even though `"UK"` has seen some use at Zalando.
 | `string` | `iso-4217` | three letter currency code -- see {ISO-4217}[ISO 4217] | `"EUR"`
 | `string` | `gtin-13` | Global Trade Item Number -- see {GTIN}[GTIN] | `"5710798389878"`
 | `string` | `regex` | regular expressions as defined in {ECMA-262}[ECMA 262] | `"^[a-z0-9]+$"`
@@ -126,7 +126,8 @@ represented as strings formatted as defined by {ISO-8601}[ISO 8601]
 ({RFC-3339}#appendix-A[RFC 3339 Appendix A contains a grammar] for `durations`
 and `periods` - the latter called time intervals in {ISO-8601}[ISO 8601]). ISO
 8601:1-2019 defines an  extension (`..`) to express open ended time intervals
-that are very convenient in searches and are included in the below grammar:
+that are very convenient in searches and are included in the below
+{RFC-2234}[ABNF] grammar:
 
 [source,abnf]
 ----
@@ -147,8 +148,9 @@ that are very convenient in searches and are included in the below grammar:
    period            = period-explicit / period-start / period-end
 ----
 
-A time interval query parameters should use `*_between` instead of the tuple
-`*_before`/`*_after`, while properties should be named using `*_interval`.
+A time interval query parameters should use `<time-property>_between` instead
+of the parameter tuple `<time-property>_before`/`<time-property>_after`, while
+properties providing a time interval should be named `<time-property>_interval`.
 
 
 [#128]
@@ -171,14 +173,15 @@ As a specific case of <<238>> you must use the following standard formats:
 [#244]
 == {SHOULD} use content negotiation, if clients may choose from different resource representations
 
-In some situations the API supports serving different representations of a specific resource (at the same URL)
-e.g. JSON, PDF, TEXT, or HTML representations for an invoice resource.
-You should use https://en.wikipedia.org/wiki/Content_negotiation[content negotiation]
-to support clients specifying via the standard HTTP headers
-{Accept}, {Accept-Language}, {Accept-Encoding} which representation is best suited for their use case,
-for example, which language of a document, representation / content format, or content encoding.
-You <<172>> like `application/json` or `application/pdf` for defining the content
-format in the {Accept} header.
+In some situations the API supports serving different representations of a
+specific resource (at the same URL), e.g. JSON, PDF, TEXT, or HTML
+representations for an invoice resource. You should use
+https://en.wikipedia.org/wiki/Content_negotiation[content negotiation] to
+support clients specifying via the standard HTTP headers {Accept},
+{Accept-Language}, {Accept-Encoding} which representation is best suited for
+their use case, for example, which language of a document, representation /
+content format, or content encoding. You <<172>> like `application/json` or
+`application/pdf` for defining the content format in the {Accept} header.
 
 
 [#144]

--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -264,9 +264,9 @@ We define the following common field names:
   identification of customers due to legacy reasons. (Hint: `customer_id` used to be defined
   as internal only, technical integer key, see
   {customer-naming-decision}[Naming Decision: `customer_number` vs `customer_id` [internal_link]]).
-* [[etag]]{etag}: the <<182, ETag>> of an <<158, embedded sub-resource>>. It
-  typically is used to carry the {ETag} for subsequent {PUT}/{PATCH} calls (see
-  <<etag-in-result-entities>>).
+* [[etag]]{e_tag}: the {e_tag} of an <<158, embedded sub-resource>>. It
+  typically is used to carry the {ETag} for subsequent {PUT}/{PATCH} calls
+  (see <<182, `ETag`>> and <<etag-in-result-entities>>).
 
 Further common fields are defined in <<235>>.
 The following guidelines define standard objects and fields:

--- a/chapters/references.adoc
+++ b/chapters/references.adoc
@@ -33,7 +33,7 @@ This section collects links to documents to which we refer, and base our guideli
 * *{RFC-4648}[RFC 4648]:* The Base16, Base32, and Base64 Data Encodings
 
 * *{ISO-8601}[ISO 8601]:* Date and time format
-* *{ISO-3166-1-a2}[ISO 3166-1 alpha-2]:* Two letter country codes
+* *{ISO-3166-1-alpha-2}[ISO 3166-1 alpha-2]:* Two letter country codes
 * *{ISO-639-1}[ISO 639-1]:* Two letter language codes
 * *{ISO-4217}[ISO 4217]:* Currency codes
 * *{BCP47}[BCP 47]:* Tags for Identifying Languages

--- a/index.adoc
+++ b/index.adoc
@@ -59,7 +59,7 @@
 :GTIN: https://en.wikipedia.org/wiki/Global_Trade_Item_Number
 :IEEE-754-2008: https://en.wikipedia.org/wiki/IEEE_754
 :ISO-8601: https://en.wikipedia.org/wiki/ISO_8601
-:ISO-3166-1-a2: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+:ISO-3166-1-alpha-2: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 :ISO-639-1: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 :ISO-4217: https://en.wikipedia.org/wiki/ISO_4217
 
@@ -155,7 +155,7 @@
 :modified: pass:[<a href="#modified"><code>modified</code></a>]
 :modified_at: pass:[<a href="#modified_at"><code>modified_at</code></a>]
 :type: pass:[<a href="#type"><code>type</code></a>]
-:etag: pass:[<a href="#etag"><code>etag</code></a>]
+:e_tag: pass:[<a href="#etag"><code>etag</code></a>]
 
 
 // Attributes to improve linking to semantic fields.

--- a/index.adoc
+++ b/index.adoc
@@ -17,6 +17,7 @@
 // Some link short cuts.
 // links to RFCs and standards:
 :RFC-1034: https://tools.ietf.org/html/rfc1034
+:RFC-2234: https://tools.ietf.org/html/rfc2234
 :RFC-2616: https://tools.ietf.org/html/rfc2616
 :RFC-2673: https://tools.ietf.org/html/rfc2673
 :RFC-3339: https://tools.ietf.org/html/rfc3339


### PR DESCRIPTION
fixes #641.

Improves the guidance on time `interval` and `duration` usage and adds some small changes we have detected over the last month where we have to be more specific about the usage of `(data-)formats` in the guideline.

Also fixes some small `etag` property presentation issue. 