### PR TITLE
Event consumers must be robust against duplicates

### DIFF
--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -658,33 +658,26 @@ for additional information.
 
 
 [#211]
-== {MUST} use unique event identifiers
+== {MUST} provide unique event identifiers
 
-The `eid` (event identifier) value of an event must be unique.
+Event publishers must provide the `eid` (event identifier) as a standard 
+event object field and part of the event <<metadata,metadata>>. 
+The `eid` must be a unique identifier for the event in the scope of the 
+event type / stream lifetime. 
 
-The `eid` property is part of the standard <<event-metadata,metadata>>
-for an event and gives the event an identifier. Producing clients must
-generate this value when sending an event and it must be guaranteed to
-be unique from the perspective of the owning application. In particular
-events within a given event type's stream must have unique identifiers.
-This allows consumers to process the `eid` to assert the event is unique
-and use it as an idempotency check.
+Event producers must use the same `eid` when publishing the same event object 
+multiple times. For instance, producers must ensure that publish event 
+retries -- e.g. due to temporary Nakadi or network failures or fail-overs -- use 
+the same `eid` value as the initial (possibly failed) attempt. 
 
-It is the responsibility of the producer to ensure event identifiers do
-in fact distinctly identify events published for a specific event type.
-A straightforward way to create a unique identifier for an event is to
-generate a UUID value. However, event producers need to ensure that
-retried attempts to publish an event, e.g. as a mitigation of temporary
-Nakadi or network failures, use the same event identifier as the initial
-(possibly failed) attempt.
+The `eid` supports event consumers in detecting and being robust against 
+event duplicates -- see <<214>>.
 
-*Hint:* Using the same `eid` for retries can be ensured, e.g. by
-deterministic UUID computation functions, which are only based on event
-attributes (producing UUIDs without random components), or some form of
-intermediate persistence, like an event publishing retry queue.
-
-Event identifiers facilitate event duplicate detection by event consumers --
-see <<214>>.
+*Hint:* Using the same eid for retries can be ensured, for instance, by 
+generating a UUID either (i) as part of the event object construction and 
+using some form of intermediate persistence, like an event publish retry 
+queue, or (ii) via a deterministic function that computes the UUID value 
+from the event fields as input (without random salt). 
 
 
 [#201]
@@ -838,21 +831,42 @@ access control and compliance and generally increases data protection risks.
 
 
 [#214]
-== {MUST} prepare event consumers for duplicate events
+== {MUST} be robust against duplicates when consuming events
 
-Event consumers must be able to process duplicate events.
+Duplicate events are multiple occurrences of the same event object representing 
+the same (business or data change) event instance. 
 
-Most message brokers and data streaming systems offer "at-least-once"
-delivery. That is, one particular event is delivered to the consumers
-one or more times. Other circumstances can also cause duplicate events.
+Event consumers must be robust against duplicate events. Depending on the use case, 
+being robust implies that event consumers need to _deduplicate events_, i.e. to ignore 
+duplicates in event processing. For instance, for accounting reporting a high accuracy 
+is required by the business, and duplicates need to be explicitly ignored, whereas 
+customer behavior reporting (click rates) might not care about event duplicates 
+since accuracy in per-mille range is not needed.
 
-For example, these situations occur if the publisher sends an event and
-doesn't receive the acknowledgment (e.g. due to a network issue). In
-this case, the publisher will try to send the same event again. This
-leads to two identical events in the event bus which have to be
-processed by the consumers. Similar conditions can appear on consumer
-side: an event has been processed successfully, but the consumer fails
-to confirm the processing.
+*Hint:* Event consumers are supported in deduplication: 
+
+* Deduplication can be based on the `eid` as mandatory standard for all events -- see <<211>>.
+* Processing data change events to replay data changes and keep transactional 
+data copies in sync (CDC) is robust against duplicates because it is based on 
+data keys and change ordering -- see <<202>> and <<242>>. 
+* Data analytics users of the Data Lake are well advised to use curated data as a 
+source for analytics. Raw event datasets materialized in the lake are typically 
+cleaned-up (including deduplication and data synchronization) and provided as 
+transactional data copy or curated data products, for instance 
+https://curated-product-data.docs.zalando.net/[curated product data [internal link]] or 
+https://curated-sales-data.docs.zalando.net/[curated sales data [internal link]]. 
+
+*Context:* One _source of duplicate events_ are the event producers, for instance, 
+due to publish call retries or publisher client failovers. Another source is 
+Nakadi's 'at-least-once' delivery promise (like provided by most message broker 
+distributed systems). It also applies to the Data Lake event materialization as 
+raw event datasets (in Delta or JSON format) for Data Analytics. 
+From an event consumer point of view, duplicate events may also be created when 
+consumers reprocess parts of the event stream, for instance, due to inaccurate 
+continuation after failures. Event publishers and infrastructure systems should 
+keep event duplication at a minimum typically below per-mille range. 
+(In Nov. 2022, for instance, we observed <0.2 ‰ daily event duplicate 
+rate (95th percentile) for high volume events.)
 
 
 [#212]

--- a/chapters/events.adoc
+++ b/chapters/events.adoc
@@ -859,8 +859,8 @@ https://curated-sales-data.docs.zalando.net/[curated sales data [internal link]]
 *Context:* One _source of duplicate events_ are the event producers, for instance, 
 due to publish call retries or publisher client failovers. Another source is 
 Nakadi's 'at-least-once' delivery promise (like provided by most message broker 
-distributed systems). It also applies to the Data Lake event materialization as 
-raw event datasets (in Delta or JSON format) for Data Analytics. 
+distributed systems). It also currently applies to the Data Lake event materialization
+as raw event datasets (in Delta or JSON format) for Data Analytics. 
 From an event consumer point of view, duplicate events may also be created when 
 consumers reprocess parts of the event stream, for instance, due to inaccurate 
 continuation after failures. Event publishers and infrastructure systems should 


### PR DESCRIPTION
Improves clarity and provided context information. 
It is important to create a clear understanding of event duplicates, that event producers support deduplication, and event consumers ensure to be robust against duplicates to avoid business processing failures or analytical data quality issues  (see internal (!) paper: https://docs.google.com/document/d/1lGfKcKqncX04QTmL0moq9RRefDpcm-itJoJLuN4CrhA/edit#)