### PR TITLE
Reformat status codes into sections

### DIFF
--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -6,6 +6,16 @@
 make all
 ----
 
+== Watch for changes and rebuild
+
+[source,bash]
+----
+make watch
+----
+
+It uses https://github.com/watchexec/watchexec[watchexec] to watch for
+changes in the `.adoc` (and `.css`) files to rebuild the html on save.
+
 == Generate Custom CSS
 
 In order to generate custom CSS we have to use http://asciidoctor.org/docs/user-manual/#stylesheet-factory[`stylesheet-factory`]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DIRWORK := $(shell pwd -P)
 
 .PHONY: all clean install lint format pull assets rules html pdf epub force
 .PHONY: check check-rules check-rules-duplicates check-rules-incorrects
-.PHONY: next-rule-id
+.PHONY: next-rule-id watch
 
 all: clean html pdf epub rules
 clean:
@@ -61,6 +61,9 @@ rules: check-rules
 html: check assets pull
 	docker run -v $(DIRWORK):$(DIRMOUNTS)/ ${DOCKER} asciidoctor \
 	  -D $(DIRMOUNTS)/$(DIRBUILDS) index.adoc;
+
+watch:
+	watchexec --exts adoc,css --ignore output -r make html
 
 pdf: check pull
 	docker run -v $(DIRWORK):$(DIRMOUNTS)/ ${DOCKER} asciidoctor-pdf -v \

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -81,22 +81,25 @@ a clear description of the HTTP status code in the response.
 
 A more specific version of the <<conventions-used-in-these-guidelines>>.
 
-[[status-code-use-mustnot]]
-==== {use-mustnot}
-We do not see a good use-case for returning this status code from a RESTful API. The status code might be applicable in other contexts, e.g. returned by reverse proxies, for web pages, etc.
-
-[[status-code-use-should]]
-==== {use-should}
+[[status-code-use]]
+==== {use}
 A common, well understood status code that should be used where appropriate.
 Does NOT mean that every operation must be able to return this code.
 
-[[status-code-doc-should]]
-==== {doc-should}
+[[status-code-do-not-use]]
+==== {do-not-use}
+We do not see a good use-case for returning this status code from a RESTful API.
+The status code might be applicable in other contexts, e.g. returned by reverse
+proxies, for web pages, etc. Implicitly also means {do-not-document}, as
+status codes that are not returned by the API should also not be documented.
+
+[[status-code-document]]
+==== {document}
 If the status code can be returned by the API, it should be documented in the
 API specification.
 
-[[status-code-doc-shouldnot]]
-==== {doc-shouldnot}
+[[status-code-do-not-document]]
+==== {do-not-document}
 The status code has a well-understood standard meaning to it, so only document
 it if there are operation specific details you want to add. See exception in
 <<151, rule 151>>.
@@ -106,14 +109,14 @@ it if there are operation specific details you want to add. See exception in
 
 
 [[status-code-200]]
-==== 200 OK {rfc-status-200} {use-should} {doc-should} {ALL}
+==== 200 OK {rfc-status-200} {use} {document} {ALL}
 [.indent]
 This is the most general success response and used, 
 if the more specific codes below are not applicable. 
 
 
 [[status-code-201]]
-==== 201 Created {rfc-status-201} {use-should} {doc-should} {POST} {PUT}
+==== 201 Created {rfc-status-201} {use} {document} {POST} {PUT}
 [.indent]
 Returned on successful resource creation. 
 {201} is returned with or without response payload (unlike {200} / {204}).
@@ -122,19 +125,19 @@ response header (see <<standard-headers>>).
 
 
 [[status-code-202]]
-==== 202 Accepted {rfc-status-202} {use-should} {doc-should} {POST} {PUT} {PATCH} {DELETE}
+==== 202 Accepted {rfc-status-202} {use} {document} {POST} {PUT} {PATCH} {DELETE}
 [.indent]
 The request was successful and will be processed asynchronously.
 
 
 [[status-code-204]]
-==== 204 No content {rfc-status-204} {doc-should} {PUT} {PATCH} {DELETE}
+==== 204 No content {rfc-status-204} {document} {PUT} {PATCH} {DELETE}
 [.indent]
 Returned instead of {200} if no response payload is returned. 
 
 
 [[status-code-207]]
-==== 207 Multi-Status {rfc-status-207} {use-should} {doc-should} {POST} ({DELETE})
+==== 207 Multi-Status {rfc-status-207} {use} {document} {POST} ({DELETE})
 [.indent]
 Multi-Status - The response body contains status information for multiple
 different parts of a batch/bulk request (see <<152>>).
@@ -146,21 +149,21 @@ different parts of a batch/bulk request (see <<152>>).
 
 
 [[status-code-301]]
-==== 301 Moved Permanently {rfc-status-301} {doc-shouldnot} {ALL}
+==== 301 Moved Permanently {rfc-status-301} {do-not-document} {ALL}
 [.indent]
 This and all future requests should be directed to the
 given URI.
 
 
 [[status-code-303]]
-==== 303 See Other {rfc-status-303} {doc-shouldnot} {POST} {PUT} {PATCH} {DELETE}
+==== 303 See Other {rfc-status-303} {do-not-document} {POST} {PUT} {PATCH} {DELETE}
 [.indent]
 The response to the request can be found under another URI using a
 {GET} method.
 
 
 [[status-code-304]]
-==== 304 Not Modified {rfc-status-304} {doc-shouldnot} {GET} {HEAD}
+==== 304 Not Modified {rfc-status-304} {do-not-document} {GET} {HEAD}
 [.indent]
 Indicates that a conditional GET or HEAD request would have
 resulted in 200 response if it were not for the fact that the condition evaluated
@@ -171,7 +174,7 @@ via request headers If-Modified-Since or If-None-Match.
 === Client side error codes
 
 [[status-code-400]]
-==== 400 Bad request {rfc-status-400} {doc-shouldnot} {ALL}
+==== 400 Bad request {rfc-status-400} {do-not-document} {ALL}
 [.indent]
 Unspecific client error indicating that the server cannot process the request 
 due to something that is perceived to be a client error (e.g. malformed request syntax invalid request).
@@ -180,45 +183,45 @@ validation (instead of using status code 422).
 
 
 [[status-code-401]]
-==== 401 Unauthorized {rfc-status-401} {use-should} {doc-shouldnot} {ALL}
+==== 401 Unauthorized {rfc-status-401} {use} {do-not-document} {ALL}
 [.indent]
 Actually "Unauthenticated": credentials 
 are not valid for the target resource. User must log in. 
 
 
 [[status-code-403]]
-==== 403 Forbidden {rfc-status-403} {doc-shouldnot} {ALL}
+==== 403 Forbidden {rfc-status-403} {do-not-document} {ALL}
 [.indent]
 The user is not authorized to use this resource.
 
 
 [[status-code-404]]
-==== 404 Not found {rfc-status-404} {doc-shouldnot} {ALL}
+==== 404 Not found {rfc-status-404} {do-not-document} {ALL}
 [.indent]
 The resource is not found.
 
 
 [[status-code-405]]
-==== 405 Method Not Allowed {rfc-status-405} {doc-should} {ALL}
+==== 405 Method Not Allowed {rfc-status-405} {document} {ALL}
 [.indent]
 The method is not supported see {OPTIONS}.
 
 
 [[status-code-406]]
-==== 406 Not Acceptable {rfc-status-406} {doc-shouldnot} {ALL}
+==== 406 Not Acceptable {rfc-status-406} {do-not-document} {ALL}
 [.indent]
 Resource can only generate content not acceptable according
 to the Accept headers sent in the request.
 
 
 [[status-code-408]]
-==== 408 Request timeout {rfc-status-408} {use-mustnot} {ALL}
+==== 408 Request timeout {rfc-status-408} {do-not-use} {ALL}
 [.indent]
 The server times out waiting for the resource.
 
 
 [[status-code-409]]
-==== 409 Conflict {rfc-status-409} {doc-should} {POST} {PUT} {PATCH} {DELETE}
+==== 409 Conflict {rfc-status-409} {document} {POST} {PUT} {PATCH} {DELETE}
 [.indent]
 Request cannot be completed due to conflict with the current state of the target resource.
 For example, you may get a {409} response when updating a resource that is older than the existing 
@@ -228,21 +231,21 @@ Hint, you should not return {409}, but {200} or {204} in case of successful robu
 
 
 [[status-code-410]]
-==== 410 Gone {rfc-status-410} {doc-shouldnot} {ALL}
+==== 410 Gone {rfc-status-410} {do-not-document} {ALL}
 [.indent]
 Resource does not exist any longer e.g. when accessing a
 resource that has intentionally been deleted.
 
 
 [[status-code-412]]
-==== 412 Precondition Failed {rfc-status-412} {doc-shouldnot} {PUT} {PATCH} {DELETE}
+==== 412 Precondition Failed {rfc-status-412} {do-not-document} {PUT} {PATCH} {DELETE}
 [.indent]
 Returned for conditional requests, e.g. {If-Match} if the
 condition failed. Used for optimistic locking.
 
 
 [[status-code-415]]
-==== 415 Unsupported Media Type {rfc-status-415} {doc-shouldnot} {POST} {PUT} {PATCH} {DELETE}
+==== 415 Unsupported Media Type {rfc-status-415} {do-not-document} {POST} {PUT} {PATCH} {DELETE}
 [.indent]
 Clients sends request body without content type.
 
@@ -254,14 +257,14 @@ Pessimistic locking, e.g. processing states.
 
 
 [[status-code-428]]
-==== 428 Precondition Required {rfc-status-428} {doc-shouldnot} {ALL}
+==== 428 Precondition Required {rfc-status-428} {do-not-document} {ALL}
 [.indent]
 Server requires the request to be conditional, e.g. to
 make sure that the "lost update problem" is avoided (see <<181>>).
 
 
 [[status-code-429]]
-==== 429 Too many requests {rfc-status-429} {doc-shouldnot} {ALL}
+==== 429 Too many requests {rfc-status-429} {do-not-document} {ALL}
 [.indent]
 The client does not consider rate limiting and sent too
 many requests (see <<153>>).
@@ -269,7 +272,7 @@ many requests (see <<153>>).
 === Server side error codes
 
 [[status-code-500]]
-==== 500 Internal Server Error {rfc-status-500} {doc-shouldnot} {ALL}
+==== 500 Internal Server Error {rfc-status-500} {do-not-document} {ALL}
 [.indent]
 A generic error indication for an unexpected server
 execution problem (here, client retry may be sensible)
@@ -283,7 +286,7 @@ availability, e.g. new feature).
 
 
 [[status-code-503]]
-==== 503 Service Unavailable {rfc-status-503} {doc-shouldnot} {ALL}
+==== 503 Service Unavailable {rfc-status-503} {do-not-document} {ALL}
 [.indent]
 Service is (temporarily) not available (e.g. if a
 required component or downstream service is not available) -- client retry may

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -76,165 +76,225 @@ HTTP status code is not in the list below or its usage requires additional
 information aside the well defined semantic, the API specification must provide
 a clear description of the HTTP status code in the response.
 
+[[status-code-legend]]
+=== Legend
+
+A more specific version of the <<conventions-used-in-these-guidelines>>.
+
+[[status-code-use-mustnot]]
+==== {use-mustnot}
+We do not see a good use-case for returning this status code from a RESTful API. The status code might be applicable in other contexts, e.g. returned by reverse proxies, for web pages, etc.
+
+[[status-code-use-should]]
+==== {use-should}
+A common, well understood status code that should be used where appropriate.
+Does NOT mean that every operation must be able to return this code.
+
+[[status-code-doc-should]]
+==== {doc-should}
+If the status code can be returned by the API, it should be documented in the
+API specification.
+
+[[status-code-doc-shouldnot]]
+==== {doc-shouldnot}
+The status code has a well-understood standard meaning to it, so only document
+it if there are operation specific details you want to add. See exception in
+<<151, rule 151>>.
+
+[[status-code-doc-may]]
+==== {doc-may}
+The status code has a standard meaning and you can document it for completeness,
+however it is not expected and you can omit it for brevity purposes.
 
 [[success-codes]]
 === Success codes
 
-[cols="10%,70%,20%",options="header",]
-|=======================================================================
-|Code |Meaning |Methods
-|[[status-code-200]]{200}|
-OK - this is the most general success response and used, 
-if the more specific codes below are not applicable. 
-|{ALL}
 
-|[[status-code-201]]{201}|
-Created - Returned on successful resource creation. 
+[[status-code-200]]
+==== 200 OK {rfc-status-200} {use-should} {doc-should} {ALL}
+[.indent]
+This is the most general success response and used, 
+if the more specific codes below are not applicable. 
+
+
+[[status-code-201]]
+==== 201 Created {rfc-status-201} {use-should} {doc-should} {POST} {PUT}
+[.indent]
+Returned on successful resource creation. 
 {201} is returned with or without response payload (unlike {200} / {204}).
 We recommend to additionally return the created resource URL via the `Location` 
 response header (see <<standard-headers>>).
-|{POST}, {PUT}
 
-|[[status-code-202]]{202}|
-Accepted - The request was successful and will be processed asynchronously.
-|{POST}, {PUT}, {PATCH}, {DELETE}
 
-|[[status-code-204]]{204}|
-No content - Returned instead of {200}, if no response payload is returned. 
-|{PUT}, {PATCH}, {DELETE}
+[[status-code-202]]
+==== 202 Accepted {rfc-status-202} {use-should} {doc-should} {POST} {PUT} {PATCH} {DELETE}
+[.indent]
+The request was successful and will be processed asynchronously.
 
-|[[status-code-207]]{207}|
+
+[[status-code-204]]
+==== 204 No content {rfc-status-204} {doc-should} {PUT} {PATCH} {DELETE}
+[.indent]
+Returned instead of {200} if no response payload is returned. 
+
+
+[[status-code-207]]
+==== 207 Multi-Status {rfc-status-207} {use-should} {doc-should} {POST} ({DELETE})
+[.indent]
 Multi-Status - The response body contains status information for multiple
 different parts of a batch/bulk request (see <<152>>).
-|{POST}, ({DELETE})
-|=======================================================================
+
 
 
 [[redirection-codes]]
 === Redirection codes
 
-[cols="10%,70%,20%",options="header",]
-|=======================================================================
-|Code |Meaning |Methods
-|[[status-code-301]]{301}|
-Moved Permanently - This and all future requests should be directed to the
+
+[[status-code-301]]
+==== 301 Moved Permanently {rfc-status-301} {doc-shouldnot} {ALL}
+[.indent]
+This and all future requests should be directed to the
 given URI.
-|{ALL}
 
-|[[status-code-303]]{303}|
-See Other - The response to the request can be found under another URI using a
+
+[[status-code-303]]
+==== 303 See Other {rfc-status-303} {doc-shouldnot} {POST} {PUT} {PATCH} {DELETE}
+[.indent]
+The response to the request can be found under another URI using a
 {GET} method.
-|{POST}, {PUT}, {PATCH}, {DELETE}
 
-|[[status-code-304]]{304}|
-Not Modified - indicates that a conditional GET or HEAD request would have
+
+[[status-code-304]]
+==== 304 Not Modified {rfc-status-304} {doc-may} {GET} {HEAD}
+[.indent]
+Indicates that a conditional GET or HEAD request would have
 resulted in 200 response if it were not for the fact that the condition evaluated
-to false, i.e. resource has not been modified since the date or version passed
+to false i.e. resource has not been modified since the date or version passed
 via request headers If-Modified-Since or If-None-Match.
-|{GET}, {HEAD}
-|=======================================================================
-
 
 [[client-side-error-codes]]
 === Client side error codes
 
-[cols="10%,70%,20%",options="header",]
-|=======================================================================
-|Code |Meaning |Methods
-|[[status-code-400]]{400}|
-Bad request - unspecific client error indicating that the server cannot process the request 
-due to something that is perceived to be a client error (e.g. malformed request syntax, invalid request).
+[[status-code-400]]
+==== 400 Bad request {rfc-status-400} {doc-may} {ALL}
+[.indent]
+Unspecific client error indicating that the server cannot process the request 
+due to something that is perceived to be a client error (e.g. malformed request syntax invalid request).
 Should also be delivered in case of input payload fails business logic / semantic 
 validation (instead of using status code 422). 
-|{ALL}
 
-|[[status-code-401]]{401}|
-Unauthorized - actually "Unauthenticated": credentials 
+
+[[status-code-401]]
+==== 401 Unauthorized {rfc-status-401} {doc-shouldnot} {ALL}
+[.indent]
+Actually "Unauthenticated": credentials 
 are not valid for the target resource. User must log in. 
-|{ALL}
 
-|[[status-code-403]]{403}|
-Forbidden - the user is not authorized to use this resource.
-|{ALL}
 
-|[[status-code-404]]{404}|
-Not found - the resource is not found.
-|{ALL}
+[[status-code-403]]
+==== 403 Forbidden {rfc-status-403} {doc-shouldnot} {ALL}
+[.indent]
+The user is not authorized to use this resource.
 
-|[[status-code-405]]{405}|
-Method Not Allowed - the method is not supported, see {OPTIONS}.
-|{ALL}
 
-|[[status-code-406]]{406}|
-Not Acceptable - resource can only generate content not acceptable according
+[[status-code-404]]
+==== 404 Not found {rfc-status-404} {doc-shouldnot} {ALL}
+[.indent]
+The resource is not found.
+
+
+[[status-code-405]]
+==== 405 Method Not Allowed {rfc-status-405} {doc-should} {ALL}
+[.indent]
+The method is not supported see {OPTIONS}.
+
+
+[[status-code-406]]
+==== 406 Not Acceptable {rfc-status-406} {doc-may} {ALL}
+[.indent]
+Resource can only generate content not acceptable according
 to the Accept headers sent in the request.
-|{ALL}
 
-|[[status-code-408]]{408}|
-Request timeout - the server times out waiting for the resource.
-|{ALL}
 
-|[[status-code-409]]{409}|
-Conflict - request cannot be completed due to conflict with the current state of the target resource.
+[[status-code-408]]
+==== 408 Request timeout {rfc-status-408} {use-mustnot} {doc-may} {ALL}
+[.indent]
+The server times out waiting for the resource.
+
+
+[[status-code-409]]
+==== 409 Conflict {rfc-status-409} {doc-should} {POST} {PUT} {PATCH} {DELETE}
+[.indent]
+Request cannot be completed due to conflict with the current state of the target resource.
 For example, you may get a {409} response when updating a resource that is older than the existing 
 one on the server, resulting in a version control conflict.
 Hint, you should not return {409}, but {200} or {204} in case of successful robust creation of resources 
 (via {PUT} or {POST}), if the resource already exists.
-|{POST}, {PUT}, {PATCH}, {DELETE}
 
-|[[status-code-410]]{410}|
-Gone - resource does not exist any longer, e.g. when accessing a
+
+[[status-code-410]]
+==== 410 Gone {rfc-status-410} {doc-may} {ALL}
+[.indent]
+Resource does not exist any longer e.g. when accessing a
 resource that has intentionally been deleted.
-|{ALL}
 
-|[[status-code-412]]{412}|
-Precondition Failed - returned for conditional requests, e.g. {If-Match} if the
+
+[[status-code-412]]
+==== 412 Precondition Failed {rfc-status-412} {doc-may} {PUT} {PATCH} {DELETE}
+[.indent]
+Returned for conditional requests, e.g. {If-Match} if the
 condition failed. Used for optimistic locking.
-|{PUT}, {PATCH}, {DELETE}
 
-|[[status-code-415]]{415}|
-Unsupported Media Type - e.g. clients sends request body without content type.
-|{POST}, {PUT}, {PATCH}, {DELETE}
 
-|[[status-code-423]]{423}|
-Locked - Pessimistic locking, e.g. processing states.
-|{PUT}, {PATCH}, {DELETE}
+[[status-code-415]]
+==== 415 Unsupported Media Type {rfc-status-415} {doc-may} {POST} {PUT} {PATCH} {DELETE}
+[.indent]
+Clients sends request body without content type.
 
-|[[status-code-428]]{428}|
-Precondition Required - server requires the request to be conditional, e.g. to
+
+[[status-code-423]]
+==== 423 Locked {rfc-status-423} {PUT} {PATCH} {DELETE}
+[.indent]
+Pessimistic locking, e.g. processing states.
+
+
+[[status-code-428]]
+==== 428 Precondition Required {rfc-status-428} {doc-shouldnot} {ALL}
+[.indent]
+Server requires the request to be conditional, e.g. to
 make sure that the "lost update problem" is avoided (see <<181>>).
-|{ALL}
 
-|[[status-code-429]]{429}|
-Too many requests - the client does not consider rate limiting and sent too
+
+[[status-code-429]]
+==== 429 Too many requests {rfc-status-429} {doc-may} {ALL}
+[.indent]
+The client does not consider rate limiting and sent too
 many requests (see <<153>>).
-|{ALL}
-|=======================================================================
 
+=== Server side error codes
 
-[[server-side-error-codes]]
-=== Server side error codes:
-
-[cols="10%,70%,20%",options="header",]
-|=======================================================================
-|Code |Meaning |Methods
-|[[status-code-500]]{500}|
-Internal Server Error - a generic error indication for an unexpected server
+[[status-code-500]]
+==== 500 Internal Server Error {rfc-status-500} {doc-shouldnot} {ALL}
+[.indent]
+A generic error indication for an unexpected server
 execution problem (here, client retry may be sensible)
-|{ALL}
 
-|[[status-code-501]]{501}|
-Not Implemented - server cannot fulfill the request (usually implies future
+
+[[status-code-501]]
+==== 501 Not Implemented {rfc-status-501} {ALL}
+[.indent]
+Server cannot fulfill the request (usually implies future
 availability, e.g. new feature).
-|{ALL}
 
-|[[status-code-503]]{503}|
-Service Unavailable - service is (temporarily) not available (e.g. if a
+
+[[status-code-503]]
+==== 503 Service Unavailable {rfc-status-503} {doc-shouldnot} {ALL}
+[.indent]
+Service is (temporarily) not available (e.g. if a
 required component or downstream service is not available) -- client retry may
 be sensible. If possible, the service should indicate how long the client
 should wait by setting the {Retry-After} header.
-|{ALL}
-|=======================================================================
+
 
 
 [#220]

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -101,11 +101,6 @@ The status code has a well-understood standard meaning to it, so only document
 it if there are operation specific details you want to add. See exception in
 <<151, rule 151>>.
 
-[[status-code-doc-may]]
-==== {doc-may}
-The status code has a standard meaning and you can document it for completeness,
-however it is not expected and you can omit it for brevity purposes.
-
 [[success-codes]]
 === Success codes
 
@@ -165,7 +160,7 @@ The response to the request can be found under another URI using a
 
 
 [[status-code-304]]
-==== 304 Not Modified {rfc-status-304} {doc-may} {GET} {HEAD}
+==== 304 Not Modified {rfc-status-304} {doc-shouldnot} {GET} {HEAD}
 [.indent]
 Indicates that a conditional GET or HEAD request would have
 resulted in 200 response if it were not for the fact that the condition evaluated
@@ -176,7 +171,7 @@ via request headers If-Modified-Since or If-None-Match.
 === Client side error codes
 
 [[status-code-400]]
-==== 400 Bad request {rfc-status-400} {doc-may} {ALL}
+==== 400 Bad request {rfc-status-400} {doc-shouldnot} {ALL}
 [.indent]
 Unspecific client error indicating that the server cannot process the request 
 due to something that is perceived to be a client error (e.g. malformed request syntax invalid request).
@@ -185,7 +180,7 @@ validation (instead of using status code 422).
 
 
 [[status-code-401]]
-==== 401 Unauthorized {rfc-status-401} {doc-shouldnot} {ALL}
+==== 401 Unauthorized {rfc-status-401} {use-should} {doc-shouldnot} {ALL}
 [.indent]
 Actually "Unauthenticated": credentials 
 are not valid for the target resource. User must log in. 
@@ -210,14 +205,14 @@ The method is not supported see {OPTIONS}.
 
 
 [[status-code-406]]
-==== 406 Not Acceptable {rfc-status-406} {doc-may} {ALL}
+==== 406 Not Acceptable {rfc-status-406} {doc-shouldnot} {ALL}
 [.indent]
 Resource can only generate content not acceptable according
 to the Accept headers sent in the request.
 
 
 [[status-code-408]]
-==== 408 Request timeout {rfc-status-408} {use-mustnot} {doc-may} {ALL}
+==== 408 Request timeout {rfc-status-408} {use-mustnot} {ALL}
 [.indent]
 The server times out waiting for the resource.
 
@@ -233,21 +228,21 @@ Hint, you should not return {409}, but {200} or {204} in case of successful robu
 
 
 [[status-code-410]]
-==== 410 Gone {rfc-status-410} {doc-may} {ALL}
+==== 410 Gone {rfc-status-410} {doc-shouldnot} {ALL}
 [.indent]
 Resource does not exist any longer e.g. when accessing a
 resource that has intentionally been deleted.
 
 
 [[status-code-412]]
-==== 412 Precondition Failed {rfc-status-412} {doc-may} {PUT} {PATCH} {DELETE}
+==== 412 Precondition Failed {rfc-status-412} {doc-shouldnot} {PUT} {PATCH} {DELETE}
 [.indent]
 Returned for conditional requests, e.g. {If-Match} if the
 condition failed. Used for optimistic locking.
 
 
 [[status-code-415]]
-==== 415 Unsupported Media Type {rfc-status-415} {doc-may} {POST} {PUT} {PATCH} {DELETE}
+==== 415 Unsupported Media Type {rfc-status-415} {doc-shouldnot} {POST} {PUT} {PATCH} {DELETE}
 [.indent]
 Clients sends request body without content type.
 
@@ -266,7 +261,7 @@ make sure that the "lost update problem" is avoided (see <<181>>).
 
 
 [[status-code-429]]
-==== 429 Too many requests {rfc-status-429} {doc-may} {ALL}
+==== 429 Too many requests {rfc-status-429} {doc-shouldnot} {ALL}
 [.indent]
 The client does not consider rate limiting and sent too
 many requests (see <<153>>).

--- a/index.adoc
+++ b/index.adoc
@@ -5,6 +5,7 @@
 :leveloffset: +1
 :sectlinks:
 :sectnumlevels: 1
+:icons: font
 
 :creator: Zalando SE
 :producer: Asciidoctor
@@ -143,19 +144,22 @@
 :503: pass:[<a href="#status-code-503" class="status-code">503</a>]
 
 // See http-status-codes-and-errors.adoc for explanation
-:use-mustnot: pass:quotes[link:#status-code-use-mustnot[[.status-code-hint.mustnot]#❌ MUST NOT use#]]
-:use-should: pass:quotes[link:#status-code-use-should[[.status-code-hint.should]#✅ SHOULD use#]]
-:doc-should: pass:quotes[link:#status-code-doc-should[[.status-code-hint.should]#✍️ SHOULD document#]]
-:doc-shouldnot: pass:quotes[link:#status-code-doc-shouldnot[[.status-code-hint.shouldnot]#✍️ SHOULD NOT document#]]
-:doc-may: pass:quotes[link:#status-code-doc-may[[.status-code-hint.may]#✍️ MAY document#]]
+:use-should: pass:quotes[link:#status-code-use-should[[.status-code-hint.should]#icon:check[] use#]]
+:use-mustnot: pass:quotes[link:#status-code-use-mustnot[[.status-code-hint.mustnot]#icon:times[] do not use#]]
+:doc-should: pass:quotes[link:#status-code-doc-should[[.status-code-hint.should]#icon:check[] document#]]
+:doc-shouldnot: pass:quotes[link:#status-code-doc-shouldnot[[.status-code-hint.shouldnot]#icon:times[] do not document#]]
 
 // RFC Links
 // 
-// You can regenerate them by pasting the adjacent JavaScript one-liner into the browser console while having the RFC website open
+// The RFC links below were generated using JavaScript snippets. You can
+// regenerate them by opening the corresponding RFC website, opening the browser
+// dev tools (Ctrl+Shift+I or F12) and pasting in the JavaScript one-liner in
+// the Console. It should print out the definitions below.
 
 // 
 // RFC 9110 - https://www.rfc-editor.org/rfc/rfc9110.html
 // 
+// See "RFC Links" above for instructions.
 // console.log(Array.from(document.querySelectorAll('.section-name[href^="#name-"]')).map(s => ({ m: s.innerText.match(/^(\d{3}) (.*)/), href: s.attributes["href"].value })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes,attributes[{RFC-9110}${c.href}[^RFC^^]]`).join("\n"))
 :rfc-status-100: pass:quotes,attributes[{RFC-9110}#name-100-continue[^RFC^^]]
 :rfc-status-101: pass:quotes,attributes[{RFC-9110}#name-101-switching-protocols[^RFC^^]]
@@ -209,6 +213,7 @@
 // 
 // Codes superseded by RFC 9110 were omitted.
 // 
+// See "RFC Links" above for instructions.
 // console.log(Array.from(document.querySelectorAll('.h3')).map(s => ({ m: s.innerText.match(/\S+\s+(\d{3}) .*/), href: s.querySelector("a").attributes["href"].value })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes,attributes[{RFC-4918}${c.href}[^RFC^^]]`).join("\n")) 
 :rfc-status-207: pass:quotes,attributes[{RFC-4918}#section-11.1[^RFC^^]]
 :rfc-status-423: pass:quotes,attributes[{RFC-4918}#section-11.3[^RFC^^]]
@@ -218,6 +223,7 @@
 // 
 // RFC 6585 - https://www.rfc-editor.org/rfc/rfc6585#section-3
 // 
+// See "RFC Links" above for instructions.
 // console.log(Array.from(document.querySelectorAll('.h3')).map(s => ({ m: s.innerText.match(/\S+\s+(\d{3}) .*/), href: s.querySelector("a") })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes[${c.href}[^RFC^^]]`).join("\n"))
 :rfc-status-428: pass:quotes,attributes[{RFC-6585}#section-7.1[^RFC^^]]
 :rfc-status-429: pass:quotes,attributes[{RFC-6585}#section-7.2[^RFC^^]]
@@ -315,7 +321,7 @@
 
 
 = Zalando RESTful API and Event Guidelines
-link:https://github.com/zalando/restful-api-guidelines[Github Repository] as part of 
+link:https://github.com/zalando/restful-api-guidelines[GitHub Repository] as part of 
 link:https://opensource.zalando.com/[Zalando SE Opensource]
 
 image::assets/api-zalando-small.jpg[API Guild Logo]

--- a/index.adoc
+++ b/index.adoc
@@ -105,7 +105,7 @@
 :HEAD: pass:[<a href="#head"><code>HEAD</code></a>]
 :OPTIONS: pass:[<a href="#options"><code>OPTIONS</code></a>]
 :TRACE: pass:[<a href="#trace"><code>TRACE</code></a>]
-:ALL: pass:[<code>&lt;all&gt;</code>]
+:ALL: pass:[<code title="Applicable to all HTTP methods.">&lt;all&gt;</code>]
 
 
 // Attributes to improve design and linking of HTTP status codes
@@ -139,6 +139,88 @@
 :500: pass:[<a href="#status-code-500" class="status-code">500</a>]
 :501: pass:[<a href="#status-code-501" class="status-code">501</a>]
 :503: pass:[<a href="#status-code-503" class="status-code">503</a>]
+
+// See http-status-codes-and-errors.adoc for explanation
+:use-mustnot: pass:quotes[link:#status-code-use-mustnot[[.status-code-hint.mustnot]#❌ MUST NOT use#]]
+:use-should: pass:quotes[link:#status-code-use-should[[.status-code-hint.should]#✅ SHOULD use#]]
+:doc-should: pass:quotes[link:#status-code-doc-should[[.status-code-hint.should]#✍️ SHOULD document#]]
+:doc-shouldnot: pass:quotes[link:#status-code-doc-shouldnot[[.status-code-hint.shouldnot]#✍️ SHOULD NOT document#]]
+:doc-may: pass:quotes[link:#status-code-doc-may[[.status-code-hint.may]#✍️ MAY document#]]
+
+// RFC Links
+// 
+// You can regenerate them by pasting the adjacent JavaScript one-liner into the browser console while having the RFC website open
+
+// 
+// RFC 9110 - https://www.rfc-editor.org/rfc/rfc9110.html
+// 
+// var u = new URL(document.URL); u.hash = ""; console.log(Array.from(document.querySelectorAll('.section-name[href^="#name-"]')).map(s => ({ m: s.innerText.match(/^(\d{3}) (.*)/), href: s.attributes["href"].value })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes[${u}${c.href}[^RFC^^]]`).join("\n"))
+:rfc-status-100: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-100-continue[^RFC^^]]
+:rfc-status-101: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-101-switching-protocols[^RFC^^]]
+:rfc-status-200: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-200-ok[^RFC^^]]
+:rfc-status-201: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-201-created[^RFC^^]]
+:rfc-status-202: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-202-accepted[^RFC^^]]
+:rfc-status-203: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-203-non-authoritative-infor[^RFC^^]]
+:rfc-status-204: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-204-no-content[^RFC^^]]
+:rfc-status-205: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-205-reset-content[^RFC^^]]
+:rfc-status-206: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-206-partial-content[^RFC^^]]
+:rfc-status-300: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-300-multiple-choices[^RFC^^]]
+:rfc-status-301: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-301-moved-permanently[^RFC^^]]
+:rfc-status-302: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-302-found[^RFC^^]]
+:rfc-status-303: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-303-see-other[^RFC^^]]
+:rfc-status-304: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified[^RFC^^]]
+:rfc-status-305: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-305-use-proxy[^RFC^^]]
+:rfc-status-306: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-306-unused[^RFC^^]]
+:rfc-status-307: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-307-temporary-redirect[^RFC^^]]
+:rfc-status-308: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-308-permanent-redirect[^RFC^^]]
+:rfc-status-400: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request[^RFC^^]]
+:rfc-status-401: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized[^RFC^^]]
+:rfc-status-402: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-402-payment-required[^RFC^^]]
+:rfc-status-403: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden[^RFC^^]]
+:rfc-status-404: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found[^RFC^^]]
+:rfc-status-405: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-405-method-not-allowed[^RFC^^]]
+:rfc-status-406: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-406-not-acceptable[^RFC^^]]
+:rfc-status-407: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-407-proxy-authentication-re[^RFC^^]]
+:rfc-status-408: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-408-request-timeout[^RFC^^]]
+:rfc-status-409: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict[^RFC^^]]
+:rfc-status-410: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-410-gone[^RFC^^]]
+:rfc-status-411: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-411-length-required[^RFC^^]]
+:rfc-status-412: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-412-precondition-failed[^RFC^^]]
+:rfc-status-413: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-413-content-too-large[^RFC^^]]
+:rfc-status-414: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-414-uri-too-long[^RFC^^]]
+:rfc-status-415: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-415-unsupported-media-type[^RFC^^]]
+:rfc-status-416: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-416-range-not-satisfiable[^RFC^^]]
+:rfc-status-417: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-417-expectation-failed[^RFC^^]]
+:rfc-status-418: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-418-unused[^RFC^^]]
+:rfc-status-421: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-421-misdirected-request[^RFC^^]]
+:rfc-status-422: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content[^RFC^^]]
+:rfc-status-426: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-426-upgrade-required[^RFC^^]]
+:rfc-status-500: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error[^RFC^^]]
+:rfc-status-501: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-501-not-implemented[^RFC^^]]
+:rfc-status-502: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-502-bad-gateway[^RFC^^]]
+:rfc-status-503: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-503-service-unavailable[^RFC^^]]
+:rfc-status-504: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-504-gateway-timeout[^RFC^^]]
+:rfc-status-505: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-505-http-version-not-suppor[^RFC^^]]
+
+// 
+// RFC 4918 - https://www.rfc-editor.org/rfc/rfc4918
+// 
+// Codes superseded by RFC 9110 were omitted.
+// 
+// console.log(Array.from(document.querySelectorAll('.h3')).map(s => ({ m: s.innerText.match(/\S+\s+(\d{3}) .*/), href: s.querySelector("a") })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes[${c.href}[^RFC^^]]`).join("\n"))
+:rfc-status-207: pass:quotes[https://www.rfc-editor.org/rfc/rfc4918#section-11.1[^RFC^^]]
+:rfc-status-423: pass:quotes[https://www.rfc-editor.org/rfc/rfc4918#section-11.3[^RFC^^]]
+:rfc-status-424: pass:quotes[https://www.rfc-editor.org/rfc/rfc4918#section-11.4[^RFC^^]]
+:rfc-status-507: pass:quotes[https://www.rfc-editor.org/rfc/rfc4918#section-11.5[^RFC^^]]
+
+// 
+// RFC 6585 - https://www.rfc-editor.org/rfc/rfc6585#section-3
+// 
+// console.log(Array.from(document.querySelectorAll('.h3')).map(s => ({ m: s.innerText.match(/\S+\s+(\d{3}) .*/), href: s.querySelector("a") })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes[${c.href}[^RFC^^]]`).join("\n"))
+:rfc-status-428: pass:quotes[https://www.rfc-editor.org/rfc/rfc6585#section-7.1[^RFC^^]]
+:rfc-status-429: pass:quotes[https://www.rfc-editor.org/rfc/rfc6585#section-7.2[^RFC^^]]
+:rfc-status-431: pass:quotes[https://www.rfc-editor.org/rfc/rfc6585#section-7.3[^RFC^^]]
+:rfc-status-511: pass:quotes[https://www.rfc-editor.org/rfc/rfc6585#section-7.4[^RFC^^]]
 
 // Attributes to improve common query parameters.
 :q: pass:[<a href="#q"><code>q</code></a>]

--- a/index.adoc
+++ b/index.adoc
@@ -28,6 +28,7 @@
 :RFC-4291: https://tools.ietf.org/html/rfc4291
 :RFC-4627: https://tools.ietf.org/html/rfc4627
 :RFC-4648: https://tools.ietf.org/html/rfc4648
+:RFC-4918: https://tools.ietf.org/html/rfc4918
 :RFC-5322: https://tools.ietf.org/html/rfc5322
 :RFC-5789: https://tools.ietf.org/html/rfc5789
 :RFC-5890: https://tools.ietf.org/html/rfc5890
@@ -52,6 +53,7 @@
 :RFC-7807: https://tools.ietf.org/html/rfc7807
 :RFC-8288: https://tools.ietf.org/html/rfc8288
 :RFC-8594: https://tools.ietf.org/html/rfc8594
+:RFC-9110: https://tools.ietf.org/html/rfc9110
 
 :iana-link-relations: http://www.iana.org/assignments/link-relations
 :iana-media-types: https://www.iana.org/assignments/media-types/media-types.xhtml
@@ -154,73 +156,73 @@
 // 
 // RFC 9110 - https://www.rfc-editor.org/rfc/rfc9110.html
 // 
-// var u = new URL(document.URL); u.hash = ""; console.log(Array.from(document.querySelectorAll('.section-name[href^="#name-"]')).map(s => ({ m: s.innerText.match(/^(\d{3}) (.*)/), href: s.attributes["href"].value })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes[${u}${c.href}[^RFC^^]]`).join("\n"))
-:rfc-status-100: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-100-continue[^RFC^^]]
-:rfc-status-101: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-101-switching-protocols[^RFC^^]]
-:rfc-status-200: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-200-ok[^RFC^^]]
-:rfc-status-201: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-201-created[^RFC^^]]
-:rfc-status-202: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-202-accepted[^RFC^^]]
-:rfc-status-203: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-203-non-authoritative-infor[^RFC^^]]
-:rfc-status-204: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-204-no-content[^RFC^^]]
-:rfc-status-205: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-205-reset-content[^RFC^^]]
-:rfc-status-206: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-206-partial-content[^RFC^^]]
-:rfc-status-300: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-300-multiple-choices[^RFC^^]]
-:rfc-status-301: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-301-moved-permanently[^RFC^^]]
-:rfc-status-302: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-302-found[^RFC^^]]
-:rfc-status-303: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-303-see-other[^RFC^^]]
-:rfc-status-304: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-304-not-modified[^RFC^^]]
-:rfc-status-305: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-305-use-proxy[^RFC^^]]
-:rfc-status-306: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-306-unused[^RFC^^]]
-:rfc-status-307: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-307-temporary-redirect[^RFC^^]]
-:rfc-status-308: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-308-permanent-redirect[^RFC^^]]
-:rfc-status-400: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request[^RFC^^]]
-:rfc-status-401: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized[^RFC^^]]
-:rfc-status-402: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-402-payment-required[^RFC^^]]
-:rfc-status-403: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden[^RFC^^]]
-:rfc-status-404: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found[^RFC^^]]
-:rfc-status-405: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-405-method-not-allowed[^RFC^^]]
-:rfc-status-406: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-406-not-acceptable[^RFC^^]]
-:rfc-status-407: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-407-proxy-authentication-re[^RFC^^]]
-:rfc-status-408: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-408-request-timeout[^RFC^^]]
-:rfc-status-409: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict[^RFC^^]]
-:rfc-status-410: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-410-gone[^RFC^^]]
-:rfc-status-411: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-411-length-required[^RFC^^]]
-:rfc-status-412: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-412-precondition-failed[^RFC^^]]
-:rfc-status-413: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-413-content-too-large[^RFC^^]]
-:rfc-status-414: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-414-uri-too-long[^RFC^^]]
-:rfc-status-415: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-415-unsupported-media-type[^RFC^^]]
-:rfc-status-416: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-416-range-not-satisfiable[^RFC^^]]
-:rfc-status-417: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-417-expectation-failed[^RFC^^]]
-:rfc-status-418: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-418-unused[^RFC^^]]
-:rfc-status-421: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-421-misdirected-request[^RFC^^]]
-:rfc-status-422: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content[^RFC^^]]
-:rfc-status-426: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-426-upgrade-required[^RFC^^]]
-:rfc-status-500: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error[^RFC^^]]
-:rfc-status-501: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-501-not-implemented[^RFC^^]]
-:rfc-status-502: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-502-bad-gateway[^RFC^^]]
-:rfc-status-503: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-503-service-unavailable[^RFC^^]]
-:rfc-status-504: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-504-gateway-timeout[^RFC^^]]
-:rfc-status-505: pass:quotes[https://www.rfc-editor.org/rfc/rfc9110.html#name-505-http-version-not-suppor[^RFC^^]]
+// console.log(Array.from(document.querySelectorAll('.section-name[href^="#name-"]')).map(s => ({ m: s.innerText.match(/^(\d{3}) (.*)/), href: s.attributes["href"].value })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes,attributes[{RFC-9110}${c.href}[^RFC^^]]`).join("\n"))
+:rfc-status-100: pass:quotes,attributes[{RFC-9110}#name-100-continue[^RFC^^]]
+:rfc-status-101: pass:quotes,attributes[{RFC-9110}#name-101-switching-protocols[^RFC^^]]
+:rfc-status-200: pass:quotes,attributes[{RFC-9110}#name-200-ok[^RFC^^]]
+:rfc-status-201: pass:quotes,attributes[{RFC-9110}#name-201-created[^RFC^^]]
+:rfc-status-202: pass:quotes,attributes[{RFC-9110}#name-202-accepted[^RFC^^]]
+:rfc-status-203: pass:quotes,attributes[{RFC-9110}#name-203-non-authoritative-infor[^RFC^^]]
+:rfc-status-204: pass:quotes,attributes[{RFC-9110}#name-204-no-content[^RFC^^]]
+:rfc-status-205: pass:quotes,attributes[{RFC-9110}#name-205-reset-content[^RFC^^]]
+:rfc-status-206: pass:quotes,attributes[{RFC-9110}#name-206-partial-content[^RFC^^]]
+:rfc-status-300: pass:quotes,attributes[{RFC-9110}#name-300-multiple-choices[^RFC^^]]
+:rfc-status-301: pass:quotes,attributes[{RFC-9110}#name-301-moved-permanently[^RFC^^]]
+:rfc-status-302: pass:quotes,attributes[{RFC-9110}#name-302-found[^RFC^^]]
+:rfc-status-303: pass:quotes,attributes[{RFC-9110}#name-303-see-other[^RFC^^]]
+:rfc-status-304: pass:quotes,attributes[{RFC-9110}#name-304-not-modified[^RFC^^]]
+:rfc-status-305: pass:quotes,attributes[{RFC-9110}#name-305-use-proxy[^RFC^^]]
+:rfc-status-306: pass:quotes,attributes[{RFC-9110}#name-306-unused[^RFC^^]]
+:rfc-status-307: pass:quotes,attributes[{RFC-9110}#name-307-temporary-redirect[^RFC^^]]
+:rfc-status-308: pass:quotes,attributes[{RFC-9110}#name-308-permanent-redirect[^RFC^^]]
+:rfc-status-400: pass:quotes,attributes[{RFC-9110}#name-400-bad-request[^RFC^^]]
+:rfc-status-401: pass:quotes,attributes[{RFC-9110}#name-401-unauthorized[^RFC^^]]
+:rfc-status-402: pass:quotes,attributes[{RFC-9110}#name-402-payment-required[^RFC^^]]
+:rfc-status-403: pass:quotes,attributes[{RFC-9110}#name-403-forbidden[^RFC^^]]
+:rfc-status-404: pass:quotes,attributes[{RFC-9110}#name-404-not-found[^RFC^^]]
+:rfc-status-405: pass:quotes,attributes[{RFC-9110}#name-405-method-not-allowed[^RFC^^]]
+:rfc-status-406: pass:quotes,attributes[{RFC-9110}#name-406-not-acceptable[^RFC^^]]
+:rfc-status-407: pass:quotes,attributes[{RFC-9110}#name-407-proxy-authentication-re[^RFC^^]]
+:rfc-status-408: pass:quotes,attributes[{RFC-9110}#name-408-request-timeout[^RFC^^]]
+:rfc-status-409: pass:quotes,attributes[{RFC-9110}#name-409-conflict[^RFC^^]]
+:rfc-status-410: pass:quotes,attributes[{RFC-9110}#name-410-gone[^RFC^^]]
+:rfc-status-411: pass:quotes,attributes[{RFC-9110}#name-411-length-required[^RFC^^]]
+:rfc-status-412: pass:quotes,attributes[{RFC-9110}#name-412-precondition-failed[^RFC^^]]
+:rfc-status-413: pass:quotes,attributes[{RFC-9110}#name-413-content-too-large[^RFC^^]]
+:rfc-status-414: pass:quotes,attributes[{RFC-9110}#name-414-uri-too-long[^RFC^^]]
+:rfc-status-415: pass:quotes,attributes[{RFC-9110}#name-415-unsupported-media-type[^RFC^^]]
+:rfc-status-416: pass:quotes,attributes[{RFC-9110}#name-416-range-not-satisfiable[^RFC^^]]
+:rfc-status-417: pass:quotes,attributes[{RFC-9110}#name-417-expectation-failed[^RFC^^]]
+:rfc-status-418: pass:quotes,attributes[{RFC-9110}#name-418-unused[^RFC^^]]
+:rfc-status-421: pass:quotes,attributes[{RFC-9110}#name-421-misdirected-request[^RFC^^]]
+:rfc-status-422: pass:quotes,attributes[{RFC-9110}#name-422-unprocessable-content[^RFC^^]]
+:rfc-status-426: pass:quotes,attributes[{RFC-9110}#name-426-upgrade-required[^RFC^^]]
+:rfc-status-500: pass:quotes,attributes[{RFC-9110}#name-500-internal-server-error[^RFC^^]]
+:rfc-status-501: pass:quotes,attributes[{RFC-9110}#name-501-not-implemented[^RFC^^]]
+:rfc-status-502: pass:quotes,attributes[{RFC-9110}#name-502-bad-gateway[^RFC^^]]
+:rfc-status-503: pass:quotes,attributes[{RFC-9110}#name-503-service-unavailable[^RFC^^]]
+:rfc-status-504: pass:quotes,attributes[{RFC-9110}#name-504-gateway-timeout[^RFC^^]]
+:rfc-status-505: pass:quotes,attributes[{RFC-9110}#name-505-http-version-not-suppor[^RFC^^]]
 
 // 
 // RFC 4918 - https://www.rfc-editor.org/rfc/rfc4918
 // 
 // Codes superseded by RFC 9110 were omitted.
 // 
-// console.log(Array.from(document.querySelectorAll('.h3')).map(s => ({ m: s.innerText.match(/\S+\s+(\d{3}) .*/), href: s.querySelector("a") })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes[${c.href}[^RFC^^]]`).join("\n"))
-:rfc-status-207: pass:quotes[https://www.rfc-editor.org/rfc/rfc4918#section-11.1[^RFC^^]]
-:rfc-status-423: pass:quotes[https://www.rfc-editor.org/rfc/rfc4918#section-11.3[^RFC^^]]
-:rfc-status-424: pass:quotes[https://www.rfc-editor.org/rfc/rfc4918#section-11.4[^RFC^^]]
-:rfc-status-507: pass:quotes[https://www.rfc-editor.org/rfc/rfc4918#section-11.5[^RFC^^]]
+// console.log(Array.from(document.querySelectorAll('.h3')).map(s => ({ m: s.innerText.match(/\S+\s+(\d{3}) .*/), href: s.querySelector("a").attributes["href"].value })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes,attributes[{RFC-4918}${c.href}[^RFC^^]]`).join("\n")) 
+:rfc-status-207: pass:quotes,attributes[{RFC-4918}#section-11.1[^RFC^^]]
+:rfc-status-423: pass:quotes,attributes[{RFC-4918}#section-11.3[^RFC^^]]
+:rfc-status-424: pass:quotes,attributes[{RFC-4918}#section-11.4[^RFC^^]]
+:rfc-status-507: pass:quotes,attributes[{RFC-4918}#section-11.5[^RFC^^]]
 
 // 
 // RFC 6585 - https://www.rfc-editor.org/rfc/rfc6585#section-3
 // 
 // console.log(Array.from(document.querySelectorAll('.h3')).map(s => ({ m: s.innerText.match(/\S+\s+(\d{3}) .*/), href: s.querySelector("a") })).filter(c => c.m).map(c => `:rfc-status-${c.m[1]}: pass:quotes[${c.href}[^RFC^^]]`).join("\n"))
-:rfc-status-428: pass:quotes[https://www.rfc-editor.org/rfc/rfc6585#section-7.1[^RFC^^]]
-:rfc-status-429: pass:quotes[https://www.rfc-editor.org/rfc/rfc6585#section-7.2[^RFC^^]]
-:rfc-status-431: pass:quotes[https://www.rfc-editor.org/rfc/rfc6585#section-7.3[^RFC^^]]
-:rfc-status-511: pass:quotes[https://www.rfc-editor.org/rfc/rfc6585#section-7.4[^RFC^^]]
+:rfc-status-428: pass:quotes,attributes[{RFC-6585}#section-7.1[^RFC^^]]
+:rfc-status-429: pass:quotes,attributes[{RFC-6585}#section-7.2[^RFC^^]]
+:rfc-status-431: pass:quotes,attributes[{RFC-6585}#section-7.3[^RFC^^]]
+:rfc-status-511: pass:quotes,attributes[{RFC-6585}#section-7.4[^RFC^^]]
 
 // Attributes to improve common query parameters.
 :q: pass:[<a href="#q"><code>q</code></a>]

--- a/index.adoc
+++ b/index.adoc
@@ -108,7 +108,7 @@
 :HEAD: pass:[<a href="#head"><code>HEAD</code></a>]
 :OPTIONS: pass:[<a href="#options"><code>OPTIONS</code></a>]
 :TRACE: pass:[<a href="#trace"><code>TRACE</code></a>]
-:ALL: pass:[<code title="Applicable to all HTTP methods.">&lt;all&gt;</code>]
+:ALL: pass:[<a href="#http-requests"><code title="Applicable to all HTTP methods.">&lt;all&gt;</code></a>]
 
 
 // Attributes to improve design and linking of HTTP status codes

--- a/index.adoc
+++ b/index.adoc
@@ -144,10 +144,10 @@
 :503: pass:[<a href="#status-code-503" class="status-code">503</a>]
 
 // See http-status-codes-and-errors.adoc for explanation
-:use-should: pass:quotes[link:#status-code-use-should[[.status-code-hint.should]#icon:check[] use#]]
-:use-mustnot: pass:quotes[link:#status-code-use-mustnot[[.status-code-hint.mustnot]#icon:times[] do not use#]]
-:doc-should: pass:quotes[link:#status-code-doc-should[[.status-code-hint.should]#icon:check[] document#]]
-:doc-shouldnot: pass:quotes[link:#status-code-doc-shouldnot[[.status-code-hint.shouldnot]#icon:times[] do not document#]]
+:use: pass:quotes[link:#status-code-use[[.status-code-hint.should]#icon:check[] use#]]
+:do-not-use: pass:quotes[link:#status-code-do-not-use[[.status-code-hint.mustnot]#icon:times[] do not use#]]
+:document: pass:quotes[link:#status-code-document[[.status-code-hint.should]#icon:check[] document#]]
+:do-not-document: pass:quotes[link:#status-code-do-not-document[[.status-code-hint.shouldnot]#icon:times[] do not document#]]
 
 // RFC Links
 // 

--- a/sass/zalando.scss
+++ b/sass/zalando.scss
@@ -20,6 +20,51 @@
   font-weight: bold;
 }
 
+/* HTTP Status Codes custom text span syntax / roles / highlight */
+.status-code-hint {
+  border-radius: 4px;
+  border-width: 2px;
+  border-style: solid;
+  padding: 4px 2px 0px 2px;
+  font-size: 0.8em;
+}
+
+.status-code-hint.mustnot {
+  color: white;
+  background-color: red;
+  border-color: red;
+}
+
+.status-code-hint.should {
+  color: white;
+  background-color: rgb(50, 192, 50);
+  border-color: rgb(50, 192, 50);
+}
+
+.status-code-hint.shouldnot {
+  color: #595959;
+  background-color: rgb(229, 232, 45);
+  border-color: rgb(229, 232, 45);
+}
+
+.status-code-hint.may {
+  color: white;
+  background-color: rgb(105, 105, 245);
+  border-color: rgb(105, 105, 245);
+}
+
+.status-code-methods {
+  border-radius: 4px;
+  border-width: 2px;
+  border-style: solid;
+  padding: 4px 2px 0px 2px;
+  font-size: 0.8em;
+}
+
+.indent {
+  padding-left: 4rem;
+}
+
 .sect1 {
   max-width: 45em;
 }

--- a/zalando.css
+++ b/zalando.css
@@ -1266,6 +1266,21 @@ b.conum * { color: inherit !important; }
 
 .status-code, .status-code:link, .status-code:visited, .status-code:hover, .status-code:active { color: black; font-weight: bold; }
 
+/* HTTP Status Codes custom text span syntax / roles / highlight */
+.status-code-hint { border-radius: 4px; border-width: 2px; border-style: solid; padding: 4px 2px 0px 2px; font-size: 0.8em; }
+
+.status-code-hint.mustnot { color: white; background-color: red; border-color: red; }
+
+.status-code-hint.should { color: white; background-color: #32c032; border-color: #32c032; }
+
+.status-code-hint.shouldnot { color: #595959; background-color: #e5e82d; border-color: #e5e82d; }
+
+.status-code-hint.may { color: white; background-color: #6969f5; border-color: #6969f5; }
+
+.status-code-methods { border-radius: 4px; border-width: 2px; border-style: solid; padding: 4px 2px 0px 2px; font-size: 0.8em; }
+
+.indent { padding-left: 4rem; }
+
 .sect1 { max-width: 45em; }
 
 #content #toc { max-width: 45em; }


### PR DESCRIPTION
* This does not change any status code body text (apart from removing the "name" part at the beginning)
* It does not add any new status codes (e.g. from #742) 
* It _does_ add more usage and documentation hints based on internal discussions
* Links to RFCs have been added for all status codes with RFC 9110 taking precedence, filled out by RFC 4918 and RFC 6585 for the missing codes

The format, terminology used, and the usage/documentation hints are all up for discussion. The status code text bodies we can review after cleaning up the internal working doc, perhaps as a follow-up PR.

Bonus: add `make watch` for fun and profit