### PR TITLE
feat: disable pdf and epub (#753)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DIRWORK := $(shell pwd -P)
 .PHONY: check check-rules check-rules-duplicates check-rules-incorrects
 .PHONY: next-rule-id
 
-all: clean html pdf epub rules
+all: clean html rules
 clean:
 	rm -rf $(DIRBUILDS);
 
@@ -62,6 +62,7 @@ html: check assets pull
 	docker run -v $(DIRWORK):$(DIRMOUNTS)/ ${DOCKER} asciidoctor \
 	  -D $(DIRMOUNTS)/$(DIRBUILDS) index.adoc;
 
+# Not used any longer.
 pdf: check pull
 	docker run -v $(DIRWORK):$(DIRMOUNTS)/ ${DOCKER} asciidoctor-pdf -v \
 		-a pdf-fontsdir=$(DIRMOUNTS)/resources/fonts \
@@ -69,6 +70,7 @@ pdf: check pull
 	  -D $(DIRMOUNTS)/$(DIRBUILDS) index.adoc;
 	mv -f $(DIRBUILDS)/index.pdf $(DIRBUILDS)/zalando-guidelines.pdf;
 
+# Not used any longer.
 epub: check pull
 	docker run -v $(DIRWORK):$(DIRMOUNTS)/ ${DOCKER} asciidoctor-epub3 \
 	  -D $(DIRMOUNTS)/$(DIRBUILDS) index.adoc;

--- a/index.adoc
+++ b/index.adoc
@@ -236,8 +236,6 @@ link:https://opensource.zalando.com/[Zalando SE Opensource]
 
 image::assets/api-zalando-small.jpg[API Guild Logo]
 
-Other formats: link:zalando-guidelines.pdf[PDF], link:zalando-guidelines.epub[EPUB3] +
-
 ifndef::ebook-format[]
 toc::[]
 endif::ebook-format[]


### PR DESCRIPTION
This pull request removes the build of the `pdf` and the `epub` versions.

fixes #753.