### PR TITLE
meta-information: do not copy the API-ID

### DIFF
--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -88,8 +88,11 @@ API publishing date>> as order criteria you get the *version* or
 *publication history* as a sequence of API specifications.
 
 *Note*: While it is nice to use human readable API identifiers based on
-self-managed URNs, it is recommend to stick to UUIDs to relief API designers
-from any urge of changing the API identifier while evolving the API. Example:
+self-managed URNs, it is recommend to stick to a UUID (freshly generated when
+first creating the API) to relief API designers from any urge of changing
+the API identifier while evolving the API. *Do not copy the API-ID from another API!*
+
+Example:
 
 [source,yaml]
 ----

--- a/chapters/meta-information.adoc
+++ b/chapters/meta-information.adoc
@@ -90,7 +90,8 @@ API publishing date>> as order criteria you get the *version* or
 *Note*: While it is nice to use human readable API identifiers based on
 self-managed URNs, it is recommend to stick to a UUID (freshly generated when
 first creating the API) to relief API designers from any urge of changing
-the API identifier while evolving the API. *Do not copy the API-ID from another API!*
+the API identifier while evolving the API. *Do not copy an API unless you
+immediately change the API identifier in it!*
 
 Example:
 


### PR DESCRIPTION
Make it clear to not copy an API-ID.