### PR TITLE
refactor: RFC 9457 obsoletes 7807, refer to it

### DIFF
--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -357,7 +357,7 @@ number of requests made within a given window for each named entity.
 [#176]
 == {MUST} support problem JSON
 
-{RFC-7807}[RFC 7807] defines a Problem JSON object using the media type
+{RFC-9457}[RFC 9457] defines a Problem JSON object using the media type
 `application/problem+json` to provide an extensible human and machine readable
 failure information beyond the HTTP response status code to transports the
 failure kind (`type` / `title`) and the failure cause and location (`instant` /
@@ -396,14 +396,14 @@ if your API needs to return specific, additional, and more detailed error
 information.
 
 *Note:* Problem `type` and `instance` identifiers in our APIs are not meant
-to be resolved. {RFC-7807}[RFC 7807] encourages that problem types are URI
+to be resolved. {RFC-9457}[RFC 9457] encourages that problem types are URI
 references that point to human-readable documentation, *but* we deliberately
 decided against that, as all important parts of the API must be documented
 using <<101, OpenAPI>> anyway. In addition, URLs tend to be fragile and not
 very stable over longer periods because of organizational and documentation
 changes and descriptions might easily get out of sync.
 
-In order to stay compatible with {RFC-7807}[RFC 7807] we proposed to use
+In order to stay compatible with {RFC-9457}[RFC 9457] we proposed to use
 https://tools.ietf.org/html/rfc3986#section-4.1[relative URI references]
 usually defined by `absolute-path [ '?' query ] [ '#' fragment ]` as simplified
 identifiers in `type` and `instance` fields:

--- a/chapters/references.adoc
+++ b/chapters/references.adoc
@@ -24,10 +24,10 @@ This section collects links to documents to which we refer, and base our guideli
 * *{RFC-7159}[RFC 7159]:* The JavaScript Object Notation (JSON) Data Interchange Format
 * *{RFC-7240}[RFC 7240]:* Prefer Header for HTTP
 * *{RFC-7396}[RFC 7396]:* JSON Merge Patch
-* *{RFC-7807}[RFC 7807]:* Problem Details for HTTP APIs
 * *{RFC-8288}[RFC 8288]:* Web Linking
 * *{RFC-9110}[RFC 9110]:* HTTP Semantics
 * *{RFC-9111}[RFC 9111]:* HTTP Caching
+* *{RFC-9457}[RFC 9457]:* Problem Details for HTTP APIs
 
 * *{ISO-8601}[ISO 8601]:* Date and time format
 * *{ISO-3166-1-alpha-2}[ISO 3166-1 alpha-2]:* Two letter country codes

--- a/index.adoc
+++ b/index.adoc
@@ -49,11 +49,11 @@
 :RFC-7240: https://tools.ietf.org/html/rfc7240
 :RFC-7396: https://tools.ietf.org/html/rfc7396
 :RFC-7493: https://tools.ietf.org/html/rfc7493
-:RFC-7807: https://tools.ietf.org/html/rfc7807
 :RFC-8288: https://tools.ietf.org/html/rfc8288
 :RFC-8594: https://tools.ietf.org/html/rfc8594
 :RFC-9110: https://tools.ietf.org/html/rfc9110
 :RFC-9111: https://tools.ietf.org/html/rfc9111
+:RFC-9457: https://tools.ietf.org/html/rfc9457
 
 :iana-link-relations: http://www.iana.org/assignments/link-relations
 :iana-media-types: https://www.iana.org/assignments/media-types/media-types.xhtml

--- a/models/problem-1.0.1.yaml
+++ b/models/problem-1.0.1.yaml
@@ -6,7 +6,7 @@ Problem:
       format: uri-reference
       description: >
         A URI reference that uniquely identifies the problem type only in the
-        context of the provided API. Opposed to the specification in RFC-7807,
+        context of the provided API. Opposed to the specification in RFC-9457,
         it is neither recommended to be dereferenceable and point to a
         human-readable documentation nor globally unique for the problem type.
       default: 'about:blank'


### PR DESCRIPTION
No substantial changes that would run at odds with the elaboration in the guidelines that I can see.