### PR TITLE
Explicitly restrict datetimes to uppercase T/Z

### DIFF
--- a/chapters/data-formats.adoc
+++ b/chapters/data-formats.adoc
@@ -98,6 +98,12 @@ As a specific case of <<238>>, you must use the `string` typed formats
 The formats are based on the standard {RFC-3339}[RFC 3339] internet profile -- a
 subset of https://tools.ietf.org/html/rfc3339#ref-ISO8601[ISO 8601]
 
+APIs {MUST} use the upper-case `T` as a separator between date and time and
+upper-case `Z` at the end when generating dates as opposed to lower-case `t`,
+`z`, space, or any other character. This is stricter than the
+https://datatracker.ietf.org/doc/html/rfc3339#section-5.6[date/time format
+as defined in RFC 3339], which leaves it up to the specification.
+
 *Exception:* For passing date/time information via standard protocol headers,
 HTTP https://tools.ietf.org/html/rfc7231#section-7.1.1.1[RFC 7231] requires to
 follow the date and time specification used by the Internet Message Format


### PR DESCRIPTION
Result of [internal discussion](https://docs.google.com/document/d/1NahSuMC0LRwFTTrln2m0iDLq0nHzGmF59Gv7xBhKPfQ/edit?disco=AAAA4qfZtcY) around datetime formats.