### PR TITLE
Update security section about uid scope

### DIFF
--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -55,11 +55,11 @@ because it exposes authentication server address details and may make use of red
 
 APIs must define permissions to protect their resources. Thus, at least one
 permission must be assigned to each API endpoint. You should use the `uid`
-pseudo-scope to allow read-only (?) access to public and employee-only data
-(classified as `green` and `yellow` respectively). For sensitive data (`orange`
-or `red`), the `uid` scope based authorization must be either accompanied by
-individual object level authorization or use role based permissions through
-specific scopes.
+pseudo-scope to allow access to public and employee-only data (classified as
+`green` and `yellow` respectively). For sensitive data (`orange` or `red`),
+the `uid` scope based authorization must be either accompanied by individual
+object level authorization or use role based permissions through specific
+scopes.
 
 The naming schema for permissions corresponds to the naming schema for <<224,
 hostnames>> and <<213, event type names>>. Please refer to <<225>> for

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -35,9 +35,7 @@ also <<105>>):
 [source,yaml]
 ----
 security:
-
-- BearerAuth: [ api-repository.read ]
-
+  - BearerAuth: [ api-repository.read ]
 ----
 
 

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -54,8 +54,12 @@ because it exposes authentication server address details and may make use of red
 == {MUST} define and assign permissions (scopes)
 
 APIs must define permissions to protect their resources. Thus, at least one
-permission must be assigned to each API endpoint. The `uid` default scope can be used
-for publicly available data, but should be declared explicitly (see details below).
+permission must be assigned to each API endpoint. You should use the `uid`
+pseudo-scope to allow read-only (?) access to public and employee-only data
+(classified as `green` and `yellow` respectively). For sensitive data (`orange`
+or `red`), the `uid` scope based authorization must be either accompanied by
+individual object level authorization or use role based permissions through
+specific scopes.
 
 The naming schema for permissions corresponds to the naming schema for <<224,
 hostnames>> and <<213, event type names>>. Please refer to <<225>> for

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -35,7 +35,9 @@ also <<105>>):
 [source,yaml]
 ----
 security:
-  - BearerAuth: [ api-repository.read ]
+
+- BearerAuth: [ api-repository.read ]
+
 ----
 
 
@@ -54,7 +56,8 @@ because it exposes authentication server address details and may make use of red
 == {MUST} define and assign permissions (scopes)
 
 APIs must define permissions to protect their resources. Thus, at least one
-permission must be assigned to each API endpoint.
+permission must be assigned to each API endpoint. The `uid` default scope can be used
+for publicly available data, but should be declared explicitly (see details below).
 
 The naming schema for permissions corresponds to the naming schema for <<224,
 hostnames>> and <<213, event type names>>. Please refer to <<225>> for


### PR DESCRIPTION
Add more visible note that `uid` scope is also a valid scope for publicly available data, as this is often misunderstood, even if there is text about this below in the same section.