### PR TITLE
Fix typo in introduction.adoc

### DIFF
--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -4,7 +4,7 @@
 Zalando’s software architecture centers around decoupled microservices
 that provide functionality via RESTful APIs with a JSON payload. Small
 engineering teams own, deploy and operate these microservices in their
-AWS (team) accounts. Our APIs must purely express what our systems do,
+AWS (team) accounts. Our APIs express most purely what our systems do,
 and are therefore highly valuable business assets. Designing
 high-quality, long-lasting APIs has become even more critical for us
 since we started developing our new open platform strategy, which

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -4,7 +4,7 @@
 Zalando’s software architecture centers around decoupled microservices
 that provide functionality via RESTful APIs with a JSON payload. Small
 engineering teams own, deploy and operate these microservices in their
-AWS (team) accounts. Our APIs most purely express what our systems do,
+AWS (team) accounts. Our APIs must purely express what our systems do,
 and are therefore highly valuable business assets. Designing
 high-quality, long-lasting APIs has become even more critical for us
 since we started developing our new open platform strategy, which


### PR DESCRIPTION
Hi there! Wanted to propose a fix for what appeared to be a small typo I found while reading :)

Feel free to close if I misunderstood what was meant here -- but then maybe something is unclear and could use further clarification in the doc?

ie. should it be 'Our APIs most-purely express' or 'Our APIs must purely express'? I could understand either from the context, but the meaning is different.