### PR TITLE
add deprecation hint to request vs. response header definition files

### DIFF
--- a/models/request-headers-1.0.0.yaml
+++ b/models/request-headers-1.0.0.yaml
@@ -1,3 +1,7 @@
+# This document is DEPRECATED and only maintained for backward compatibility.
+# Separation of request vs. response header definition is partially redundant and not needed. 
+# Instead, please use the HEADER DEFINITIONS provided in headers-<version>.yaml
+
 # Standard Headers
 
 If-Match:

--- a/models/response-headers-1.0.0.yaml
+++ b/models/response-headers-1.0.0.yaml
@@ -1,3 +1,7 @@
+# This document is DEPRECATED and only maintained for backward compatibility.
+# Separation of request vs. response header definition is partially redundant and not needed. 
+# Instead, please use the HEADER DEFINITIONS provided in headers-<version>.yaml
+
 # Standard Headers
 
 Cache-Control:


### PR DESCRIPTION
Clarifies that deprecated model files for request and response headers.