### PR TITLE
Remove sort example from simple query language (236)

### DIFF
--- a/chapters/http-requests.adoc
+++ b/chapters/http-requests.adoc
@@ -541,7 +541,7 @@ The following examples should serve as ideas for simple query language:
 
 * `name=Zalando`, `creation_year=2023`, `updated_by=user1` (query elements
   based on property equality)
-* `created_at=2023-09-18T12:12:00.000Z`, `sort=id:desc` (query elements
+* `created_at=2023-09-18T12:12:00.000Z`, `age=18` (query elements
   based on logical properties)
 * `color=red,green,blue,multicolored` (query elements based on multiple
   choice possibility)


### PR DESCRIPTION
The `sort=id:desc` example doesn't fit the "equality comparison for a logical property".

It also leads to confusion on how to indicate how the result should be sorted (rule 137 says `sort=-id`).

This replaces it with another "logical property", the age (which is often calculated from the birthday and current date).

_(Triggered by an [internal chat message](https://chat.google.com/room/AAAAAqZDJ28/zr5609abqFs/zr5609abqFs?cls=10).)_