### PR TITLE
"do not document" on status codes 502 + 504

### DIFF
--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -47,16 +47,6 @@ the following command to find the next unused rule identifier.
 make next-rule-id
 ----
 
-== Watch for changes and rebuild
-
-[source,bash]
-----
-make watch
-----
-
-It uses https://github.com/watchexec/watchexec[watchexec] to watch for
-changes in the `.adoc` (and `.css`) files to rebuild the html on save.
-
 == Generate Custom CSS
 
 In order to generate custom CSS we have to use

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -398,8 +398,8 @@ May be documented on endpoints that are planned to be implemented in the
 future to indicate that they are still not available.
 
 [[status-code-502]]
-==== 502 Bad Gateway {rfc-status-502} {ALL}
-[.indent]is meaningless
+==== 502 Bad Gateway {rfc-status-502} {use} {do-not-document} {ALL}
+[.indent]
 The server, while acting as a gateway or proxy, received an invalid response
 from an inbound server attempting to fulfill the request. May be used by a
 server to indicate that an inbound service is creating an unexpected result
@@ -415,7 +415,7 @@ exponential back off pattern. If possible, the service should indicate how long
 the client should wait by setting the {Retry-After} header.
 
 [[status-code-504]]
-==== 504 Gateway Timeout {rfc-status-504} {use} {ALL}
+==== 504 Gateway Timeout {rfc-status-504} {use} {do-not-document} {ALL}
 [.indent]
 The server, while acting as a gateway or proxy, did not receive a timely
 response. May be used by servers to indicate that an inbound service cannot


### PR DESCRIPTION
This was missed before, noticed in #821.

Also, fix the indentation of the text for 502, and remove a duplicated section in the building instructions.

