### PR TITLE
Update RFC links in request and response header models

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -46,7 +46,7 @@
 :RFC-7231: https://tools.ietf.org/html/rfc7231 // obsoleted by rfc-9110
 :RFC-7232: https://tools.ietf.org/html/rfc7232 // obsoleted by rfc-9110
 :RFC-7233: https://tools.ietf.org/html/rfc7233 // obsoleted by rfc-9110
-:RFC-7234: https://tools.ietf.org/html/rfc7234
+:RFC-7234: https://tools.ietf.org/html/rfc7234 // obsoleted by rfc-9111
 :RFC-7235: https://tools.ietf.org/html/rfc7235 // obsoleted by rfc-9110
 :RFC-7240: https://tools.ietf.org/html/rfc7240
 :RFC-7396: https://tools.ietf.org/html/rfc7396

--- a/models/request-headers-1.0.0.yaml
+++ b/models/request-headers-1.0.0.yaml
@@ -17,8 +17,9 @@ If-Match:
     outdated on arrival of the change request to prevent lost updates.
 
     If the pre-condition fails the server will respond with status code `412`
-    (Precondition Failed). For further details see [RFC 7232 Section
-    3.1](https://tools.ietf.org/html/rfc7232#section-3.1).
+    (Precondition Failed). For further details see [RFC 9110 Section
+    13.1.1. If-Match](https://datatracker.ietf.org/doc/html/rfc9110#name-if-match)
+    and [RFC 9111 Section 4.3.1 Sending a Validation Request](https://datatracker.ietf.org/doc/html/rfc9111#name-sending-a-validation-reques).
   schema:
     type: array
     items:
@@ -40,8 +41,9 @@ If-None-Match:
     of a resource. Other use cases are possible but rare.
 
     If the pre-condition fails the server will respond with status code `412`
-    (Precondition Failed). For further details see [RFC 7232 Section
-    3.2](https://tools.ietf.org/html/rfc7232#section-3.2) for further details.
+    (Precondition Failed). For further details see [RFC 9110 Section
+    13.1.2](https://datatracker.ietf.org/doc/html/rfc9110#name-if-none-match)
+    and [RFC 9111 Section 4.3.1 Sending a Validation Request](https://datatracker.ietf.org/doc/html/rfc9111#name-sending-a-validation-reques).
   schema:
     type: array
     items:

--- a/models/response-headers-1.0.0.yaml
+++ b/models/response-headers-1.0.0.yaml
@@ -11,8 +11,8 @@ Cache-Control:
     The `Cache-Control` header field is providing directives to control how
     proxies and clients are allowed to cache responses results for performance.
     Clients and proxies are free to not support caching of results, however if
-    they do, they must obey all directives mentioned in [RFC-7234 Section
-    5.2.2](https://tools.ietf.org/html/rfc7234) to the word.
+    they do, they must obey all directives mentioned in [RFC-9111 Section
+    5.2.2](https://datatracker.ietf.org/doc/html/rfc9111#name-response-directives) to the word.
 
     In case of caching, the directive provides the scope of the cache entry,
     i.e. only for the original user (private) or shared between all users
@@ -33,7 +33,8 @@ Vary:
     request target path, might have influence the server in selecting the
     presented response. A client or proxy that caches the response must respect
     this information to ensure that it delivers the correct cache entry (see
-    [RFC-7231 Section 7.1.4](https://tools.ietf.org/html/rfc7231#section-7.1.4)).
+    [RFC 9110 Section 12.5.5. Vary](https://datatracker.ietf.org/doc/html/rfc9110#name-vary)
+    and [RFC 9111 Section 4.1 Calculating Cache Keys with the Vary Header Field](https://datatracker.ietf.org/doc/html/rfc9111#name-calculating-cache-keys-with)).
 
     The value consists of either a single asterisk (`*`) or a list of
     case-insensitive header field names.
@@ -52,8 +53,9 @@ ETag:
     resource changes, and thereby enabling optimistic updates.
 
     An identifier consists of an opaque quoted string, possibly prefixed by
-    a weakness indicator. For further details see [RFC 7232 Section
-    2.3](https://tools.ietf.org/html/rfc7232#section-2.3).
+    a weakness indicator. For further details see [RFC 9110 Section
+    8.8.3. ETag](https://datatracker.ietf.org/doc/html/rfc9110#name-etag) and
+    [RFC 9111 Section 4.3.1 Sending a Validation Request](https://datatracker.ietf.org/doc/html/rfc9111#name-sending-a-validation-reques)
   schema:
     type: string
     example: 'W/"xy", "5", "5db68c06-1a68-11e9-8341-68f728c1ba70"''


### PR DESCRIPTION
When doing the change for #830, I noticed that the model YAML files also still pointed to the old RFCs in the descriptions.
This changes the links (and a bit text around it) to point to the current generation of HTTP RFCs.