### PR TITLE
Fix typo in "Prefered" Header section

### DIFF
--- a/models/headers-1.0.0.yaml
+++ b/models/headers-1.0.0.yaml
@@ -136,7 +136,7 @@ Prefer:
       and report error conditions or lenient, i.e. robust and try to continue,
       if possible.
 
-    See [RFC 7340][rfc-7240] as well as [API Guideline Rule #181][api-181]
+    See [RFC 7240][rfc-7240] as well as [API Guideline Rule #181][api-181]
     for further details.
 
     [rfc-7240]: <https://tools.ietf.org/html/rfc7240>


### PR DESCRIPTION
Copy of #825, as I couldn't merge that one.
Just a typo in the header models.

Thanks to @kai-jellinghaus for the contribution.