### PR TITLE
Deduplicate and simplify custom header example (X-Device-Type) 

### DIFF
--- a/chapters/http-headers.adoc
+++ b/chapters/http-headers.adoc
@@ -409,11 +409,8 @@ request or response. Hop-by-hop headers, on the contrary, are meaningful for a
 single connection only.] and must be propagated to the services down the call
 chain. The header names and values must remain unchanged.
 
-For example, the values of the custom headers like {X-Device-Type} can affect
-the results of queries by using device type information to influence
-recommendation results. Besides, the values of the custom headers can influence
-the results of the queries (e.g. the device type information influences the
-recommendation results).
+The values of custom headers can influence query results (e.g. {X‑Device‑Type} can 
+affect recommendation results by conveying device‑type information).
 
 Sometimes the value of a proprietary header will be used as part of the entity
 in a subsequent request. In such cases, the proprietary headers must still be


### PR DESCRIPTION
Removed a redundant five-line paragraph about custom headers influencing query results and replaced it with a simple sentence.