### PR TITLE
Fix incorrect hyphen in {X-Device-Type} example (follow-up to #835)

### DIFF
--- a/chapters/http-headers.adoc
+++ b/chapters/http-headers.adoc
@@ -409,7 +409,7 @@ request or response. Hop-by-hop headers, on the contrary, are meaningful for a
 single connection only.] and must be propagated to the services down the call
 chain. The header names and values must remain unchanged.
 
-The values of custom headers can influence query results (e.g. {X‑Device‑Type} can 
+The values of custom headers can influence query results (e.g. {X-Device-Type} can
 affect recommendation results by conveying device‑type information).
 
 Sometimes the value of a proprietary header will be used as part of the entity


### PR DESCRIPTION
Apologies for my mistake  😢
In PR #835, I accidentally used incorrect hyphen...  (`‑` ,U+2011), which caused rendering issues in AsciiDoc.
This PR replace it with ASCII hyphen(`-` ,U+002D).


before: 
![image](https://github.com/user-attachments/assets/8ffeb2c4-3a92-4761-8daa-fe4703d04287)


after:
![image](https://github.com/user-attachments/assets/a8529ca5-5b62-4994-a0d9-5e67896a12d0)

