### PR TITLE
fix: typo in date/time properties naming convention data-time -> date-time

### DIFF
--- a/chapters/json-guidelines.adoc
+++ b/chapters/json-guidelines.adoc
@@ -148,7 +148,7 @@ declaring possible values for a <<137,rule 137>> [`sort` parameter].
 [#235]
 == {SHOULD} use naming convention for date/time properties
 
-Naming of date and data-time properties should comply with the following convention: 
+Naming of date and date-time properties should comply with the following convention: 
 The name either (i) contains `date`, `day`, `time`, `timestamp` or similar type indicators, 
 or (ii) end with the  `_at` suffix. The convention allows easy identification of date/time 
 typed properties and distinguishing them e.g. from boolean properties like `created` vs. `created_at`. 


### PR DESCRIPTION

Corrected a typo in the naming convention section for date/time properties.