### PR TITLE
fix mixup of rules 250 and 251.

### DIFF
--- a/chapters/changelog.adoc
+++ b/chapters/changelog.adoc
@@ -29,7 +29,7 @@ to see a list of all changes.
 * `2023-12-12`: Improved response code guidance in <<150>>. ^https://github.com/zalando/restful-api-guidelines/pull/789[#789]^
 * `2023-11-22`: Added new rule <<253>> for supporting asynchronous request processing. ^https://github.com/zalando/restful-api-guidelines/pull/787[#787]^
 * `2023-07-21`: Improved guidance on total counts in <<254>>. ^https://github.com/zalando/restful-api-guidelines/pull/731[#731]^
-* `2023-05-12`: Added new rule <<250>> recommending not to use redirection codes. ^https://github.com/zalando/restful-api-guidelines/pull/762[#762]^
+* `2023-05-12`: Added new rule <<251>> recommending not to use redirection codes. ^https://github.com/zalando/restful-api-guidelines/pull/762[#762]^ ^https://github.com/zalando/restful-api-guidelines/pull/781[#781]^
 * `2023-05-08`: Improved guidance on sanitizing JSON payload in <<250>>. ^https://github.com/zalando/restful-api-guidelines/pull/759[#759]^
 * `2023-04-18`: Added new rule <<252>> recommending to design single resource schema for reading and writing. Added exception for partner IAM to <<104>>. ^https://github.com/zalando/restful-api-guidelines/pull/764[#764]^ ^https://github.com/zalando/restful-api-guidelines/pull/767[#767]^
 * `2022-12-20`: Clarify that event consumers must be robust against duplicates in <<214>>. ^https://github.com/zalando/restful-api-guidelines/pull/749[#749]^

--- a/chapters/compatibility.adoc
+++ b/chapters/compatibility.adoc
@@ -58,7 +58,7 @@ services in a backward-compatible way:
 * You <<112>> that are used for output parameters and likely to
   be extended with growing functionality. The API definition should be updated
   first before returning new values.
-* Consider <<250>> in case a URL has to change.
+* Consider <<251>> in case a URL has to change.
 
 
 [#109]


### PR DESCRIPTION
Rule 251 was originally added as 250 in #762 to a feature branch, but then #759 adding 250 was merged first to main before #781 merged that feature branch to master (and renamed it).

This fixes a reference in rule 107 and in the changelog.