### PR TITLE
Add note on endpoint URL consistency for pagination

### DIFF
--- a/chapters/pagination.adoc
+++ b/chapters/pagination.adoc
@@ -173,6 +173,12 @@ For {GET-with-body} operations, the `query` object can to be used as a request
 body with either of these links. (It should be equivalent to just resend
 the original body.)
 
+An endpoint might be exposed under different URLs (the protocols, hostnames and ports may vary).
+The protocol, hostame and port of the pagination links should match the ones used in the request
+this response is for. This avoids scenarios where one would configure access-list rules that
+allow the first request to succeed only for the integration to fail the moment the number of entities
+overflows to the second page.
+
 See also <<248>> for details on the pagination fields and page result object.
 
 

--- a/chapters/pagination.adoc
+++ b/chapters/pagination.adoc
@@ -174,8 +174,7 @@ body with either of these links. (It should be equivalent to just resend
 the original body.)
 
 An endpoint might be exposed under different URLs (the protocols, hostnames and ports may vary).
-The protocol, hostame and port of the pagination links should match the ones used in the request
-this response is for. This avoids scenarios where one would configure access-list rules that
+The protocol, hostame and port of the pagination links should match the ones used in the first request. This avoids scenarios where one would configure access-list rules that
 allow the first request to succeed only for the integration to fail the moment the number of entities
 overflows to the second page.
 


### PR DESCRIPTION
# Description

We have services that render pagination links with statically preconfigured base URLs.
The same service will be exposed under multiple hostnames for compatibility reasons.

Users of such endpoints will then put effort into configuring access-list rules in client systems (e.g. ZMON) based on the behavior of the requests. During development, a single page of results is often returned.

Unbeknownst to them, the access-list rules will not apply to the pagination links since they are not guaranteed to target the same base URLs they used to fetch the first page. As soon as the number of entities grows large enough not to fit in the first page, the integration breaks and the developer has to put extra effort into investigating the problem and configuring more access-list rules.

This PR amends the [suggestion for pagination links](https://opensource.zalando.com/restful-api-guidelines/#161) with a paragraph encouraging the use of consistent base URLs.