### PR TITLE
docs: fix typos in security and error docs

### DIFF
--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -11,7 +11,7 @@ make all
 the targets are still available for experimenting.
 
 Since http://asciidoctor.org/docs[asciidoctor] does not support a linter yet,
-we have setup https://unpkg.com/browse/markdownlint-cli@0.27.1/README.md[markdownlint]
+we have set up https://unpkg.com/browse/markdownlint-cli@0.27.1/README.md[markdownlint]
 as an experiment to support coding standards. To install and check for
 violations use
 
@@ -21,7 +21,7 @@ make lint
 ----
 
 If linting with the suggested rules proves helpful we will integrate this
-target into the a `pre-commit`-hook to enforce a common style and append it
+target into a `pre-commit` hook to enforce a common style and append it
 to the `all`-target.
 
 **Note:** We have currently not tested the capability of `markdownlint` (or
@@ -66,7 +66,7 @@ In order to generate custom CSS we have to use
 http://asciidoctor.org/docs/user-manual/#stylesheet-factory[`stylesheet-factory`]
 
 This script clones the factory repository, installs the dependencies and
-generates CSS based in the `zalando.scss`
+generates CSS based on the `zalando.scss`
 
 [source,bash]
 ----

--- a/chapters/general-guidelines.adoc
+++ b/chapters/general-guidelines.adoc
@@ -34,7 +34,7 @@ control using a source code management system, and you <<192>>.
 all OpenAPI 3.1 changes (e.g. displaying `examples` in Sunrise), and continues 
 supporting OpenAPI 3.0 (and 2.0, aka Swagger 2).
 
-*Hint:* The _OpenAPI 3.1 mayor change_ is that Schema Object definitions are now 
+*Hint:* The _OpenAPI 3.1 major change_ is that Schema Object definitions are now 
 fully compliant with standard JSON Schema. It is an incompatible change since 
 OpenAPI-specific overrides and keywords like `example`, `nullable`, `discriminator`, `xml` 
 are removed from the Schema Object (see 

--- a/chapters/http-status-codes-and-errors.adoc
+++ b/chapters/http-status-codes-and-errors.adoc
@@ -424,7 +424,7 @@ exactly once, to check whether warming up the service solved the problem.
 ==== 505 HTTP Version Not Supported {rfc-status-505} {do-not-use} {ALL}
 [.indent]
 The server does not support the HTTP protocol version used in the request.
-Technical response code that serves not use case in RESTful APIs.
+Technical response code that serves no use case in RESTful APIs.
 
 [[status-code-507]]
 ==== 507 Insufficient Storage {rfc-status-507} {do-not-document} {POST} {PUT} {PATCH}

--- a/chapters/security.adoc
+++ b/chapters/security.adoc
@@ -15,7 +15,7 @@ using JWT tokens provided by the platform IAM token service. In these situations
 you should use the `http` typed
 https://swagger.io/docs/specification/authentication/bearer-authentication/[Bearer Authentication]
 security scheme -- it is based on OAuth2.0 {RFC-6750}[RFC 6750] defining the standard header
-`Auhorization: Bearer <token>`.
+`Authorization: Bearer <token>`.
 The following code snippet shows how to define the bearer security scheme.
 
 [source,yaml]
@@ -28,7 +28,7 @@ components:
       bearerFormat: JWT
 ----
 
-The bearer security schema can then be applied to all API endpoints, e.g. requiring
+The bearer security scheme can then be applied to all API endpoints, e.g. requiring
 the token to have `api-repository.read` scope for permission as follows (see
 also <<105>>):
 


### PR DESCRIPTION
## Summary

**Fixes typos and wording errors in security, error-handling, general guidelines, and build documentation.**

* Correct `Authorization` header spelling and `security scheme` terminology in `chapters/security.adoc`
* Fix "serves no use case" wording for HTTP 505 in `chapters/http-status-codes-and-errors.adoc`
* Fix "major change" typo in OpenAPI 3.1 hint in `chapters/general-guidelines.adoc`
* Fix grammar in `BUILD.adoc` (`set up`, `pre-commit` hook, `based on`)

Minor documentation-only change; no guideline rules or behavior affected.

## How to Verify

- [ ] Verify diff contains only intended typo/grammar fixes 
- [ ] make all builds successfully (optional)