### PR TITLE
Require host name consistency

### DIFF
--- a/chapters/hyper-media.adoc
+++ b/chapters/hyper-media.adoc
@@ -147,7 +147,7 @@ See <<164>> and <<161>> for more information and examples.
 
 
 [#217]
-== {MUST} use full, absolute URI for resource identification
+== {MUST} use full, absolute URI for resource identification (with same host, if applicable)
 
 Links to other resource must always use full, absolute URI.
 
@@ -158,6 +158,11 @@ when using features like embedding subresources. The primary advantage of
 non-absolute URI is reduction of the payload size, which is better achievable
 by following the recommendation to use <<156,gzip compression>>
 
+If the linked resource belongs to the same API, the link should use the same scheme + host + port combination as the original request URI. (This only comes into play when the API is available at e.g. multiple host names.)
+
+*Motivation:* This avoids cases where authorization is configured for one host
+name and not the other, or the second one might not even be accessible from the
+network location of the client (like Kubernetes cluster-internal host names).
 
 [#166]
 == {MUST} not use link headers with JSON entities

--- a/chapters/hyper-media.adoc
+++ b/chapters/hyper-media.adoc
@@ -158,9 +158,9 @@ when using features like embedding subresources. The primary advantage of
 non-absolute URI is reduction of the payload size, which is better achievable
 by following the recommendation to use <<156,gzip compression>>
 
-If the linked resource belongs to the same API, the link should use the same scheme + host + port combination as the original request URI. (This only comes into play when the API is available at e.g. multiple host names.)
+If the linked resource belongs to the same [API](https://opensource.zalando.com/restful-api-guidelines/#terminology) i.e. running service, the link should use the same scheme + host + port combination as the original request URI. (This only comes into play when the API is available at e.g. multiple host names.)
 
-*Motivation:* This avoids cases where authorization is configured for one host
+*Motivation:* This avoids inconsistent client experience situations, for instance, where authorization is configured for one host
 name and not the other, or the second one might not even be accessible from the
 network location of the client (like Kubernetes cluster-internal host names).
 

--- a/chapters/pagination.adoc
+++ b/chapters/pagination.adoc
@@ -175,6 +175,8 @@ the original body.)
 
 See also <<248>> for details on the pagination fields and page result object.
 
+See also <<217>> for what kind of URLs to use (absolute ones, with the same base
+URL as the original request).
 
 [#254]
 == {SHOULD} avoid a total result count


### PR DESCRIPTION
Replaces #866.

As discussed in today's meeting, the valid concern addressed in #866 applies to all kinds of links, not just the pagination links. As such, I've added it to rule 217, with a link at rule 161.